### PR TITLE
Validating OAuth2 token expiration date

### DIFF
--- a/edx_rest_framework_extensions/authentication.py
+++ b/edx_rest_framework_extensions/authentication.py
@@ -1,8 +1,10 @@
 """ Authentication classes. """
 
+import datetime
 import logging
 
 import requests
+from dateutil.parser import parse
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from rest_framework import exceptions
@@ -69,6 +71,12 @@ class BearerAuthentication(BaseAuthentication):
             raise exceptions.AuthenticationFailed('Invalid token.')
 
         data = response.json()
+
+        # Validate the expiration datetime
+        expires = parse(data['expires'])
+
+        if expires < datetime.datetime.utcnow():
+            raise exceptions.AuthenticationFailed('Token expired.')
 
         try:
             user = User.objects.get(username=data['username'])

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='edx-drf-extensions',
-    version='0.1.0',
+    version='0.1.1',
     description='edX extensions of Django REST Framework',
     author='edX',
     url='https://github.com/edx/edx-drf-extensions',
@@ -27,6 +27,7 @@ setup(
     install_requires=[
         'django>=1.8.9,<1.10',
         'djangorestframework>=3.2.3,<4.0.0',
+        'python-dateutil>=2.0',
         'requests>=2.7.0,<3.0.0',
     ],
 )


### PR DESCRIPTION
BearerAuthentication has been updated to actually validate the expiration time of the access token response. This ensures that users with expired tokens are NOT authenticated.

ECOM-3895