### PR TITLE
Deploying to PyPI only from the Python 3.5, Django 1.9 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,5 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
+    python: 3.5
+    condition: '$TOXENV = django19'

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '0.3.1'  # pragma: no cover
+__version__ = '0.4.0'  # pragma: no cover


### PR DESCRIPTION
This ensures we deploy once, after a successful test build.

Fixes #2