### PR TITLE
Updated JWT payload error handling

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '0.5.0'  # pragma: no cover
+__version__ = '0.5.1'  # pragma: no cover

--- a/edx_rest_framework_extensions/authentication.py
+++ b/edx_rest_framework_extensions/authentication.py
@@ -188,7 +188,7 @@ class JwtAuthentication(JSONWebTokenAuthentication):
         username = payload.get('preferred_username') or payload.get('username')
 
         if username is None:
-            raise exceptions.AuthenticationFailed('Invalid payload.')
+            raise exceptions.AuthenticationFailed('JWT must include a preferred_username or username claim!')
         else:
             try:
                 user, __ = User.objects.get_or_create(username=username)

--- a/edx_rest_framework_extensions/tests/test_authentication.py
+++ b/edx_rest_framework_extensions/tests/test_authentication.py
@@ -230,12 +230,9 @@ class JwtAuthenticationTests(TestCase):
                 logger.assert_called_with('User retrieval failed.')
 
     def test_authenticate_credentials_no_usernames(self):
-        """ Verify exceptions raised if no username specified. """
-        self.assertRaises(
-            AuthenticationFailed,
-            JwtAuthentication().authenticate_credentials,
-            {'email': 'test@example.com'}
-        )
+        """ Verify an AuthenticationFailed exception is raised if the payload contains no username claim. """
+        with self.assertRaises(AuthenticationFailed):
+            JwtAuthentication().authenticate_credentials({'email': 'test@example.com'})
 
     def test_authenticate(self):
         """ Verify exceptions raised during authentication are properly logged. """


### PR DESCRIPTION
If the username claim is missing from the JWT, the exception raised now includes a message stating this fact.

ECOM-4414