### PR TITLE
Added support for JWT claim-user attribute mapping

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '0.5.1'  # pragma: no cover
+__version__ = '1.0.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/settings.py
+++ b/edx_rest_framework_extensions/settings.py
@@ -11,7 +11,12 @@ from django.conf import settings
 
 DEFAULT_SETTINGS = {
     'OAUTH2_USER_INFO_URL': None,
-    'JWT_PAYLOAD_USER_ATTRIBUTES': ('email',)
+
+    # Map JWT claims to user attributes.
+    'JWT_PAYLOAD_USER_ATTRIBUTE_MAPPING': {
+        'administrator': 'is_staff',
+        'email': 'email',
+    },
 }
 
 


### PR DESCRIPTION
This mapping will allow consuming projects to specify which claims should be mapped to specific user model attributes. By default the email claim is mapped to the email attribute, and the administrator claim is mapped to the is_staff attribute.

 ECOM-4793