### PR TITLE
mattdrayer/multiple-jwt-issuers: Add support for multiple JWT issuers

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '1.0.0'  # pragma: no cover
+__version__ = '1.1.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/tests/test_settings.py
+++ b/edx_rest_framework_extensions/tests/test_settings.py
@@ -1,7 +1,11 @@
 """ Tests for settings. """
+import warnings
+
+import mock
+from django.conf import settings
 from django.test import TestCase, override_settings
 
-from edx_rest_framework_extensions.settings import get_setting
+from edx_rest_framework_extensions.settings import get_setting, get_jwt_issuers
 
 
 class SettingsTests(TestCase):
@@ -23,3 +27,32 @@ class SettingsTests(TestCase):
         with override_settings(EDX_DRF_EXTENSIONS=_settings):
             for key, value in _settings.items():
                 self.assertEqual(get_setting(key), value)
+
+    def test_get_current_jwt_issuers(self):
+        """
+        Verify the get_jwt_issuers operation returns the current issuer information when configured
+        """
+        self.assertEqual(get_jwt_issuers(), settings.JWT_AUTH['JWT_ISSUERS'])
+
+    def test_get_deprecated_jwt_issuers(self):
+        """
+        Verify the get_jwt_issuers operation returns the deprecated issuer information when current
+        issuers are not configured for the system.
+        """
+        _deprecated = [
+            {
+                'ISSUER': settings.JWT_AUTH['JWT_ISSUER'],
+                'SECRET_KEY': settings.JWT_AUTH['JWT_SECRET_KEY'],
+                'AUDIENCE': settings.JWT_AUTH['JWT_AUDIENCE'],
+            }
+        ]
+
+        mock_call = 'edx_rest_framework_extensions.settings._get_current_jwt_issuers'
+        with mock.patch(mock_call, mock.Mock(return_value=None)):
+            with warnings.catch_warnings(record=True) as warning_list:
+                self.assertEqual(get_jwt_issuers(), _deprecated)
+                warnings.simplefilter("default")
+                self.assertEqual(len(warning_list), 1)
+                self.assertTrue(issubclass(warning_list[-1].category, DeprecationWarning))
+                msg = "'JWT_ISSUERS' list not defined, checking for deprecated settings."
+                self.assertIn(msg, str(warning_list[-1].message))

--- a/edx_rest_framework_extensions/tests/test_utils.py
+++ b/edx_rest_framework_extensions/tests/test_utils.py
@@ -1,27 +1,34 @@
 """ Tests for utility functions. """
 from time import time
 
+import ddt
 import jwt
 import mock
 from django.conf import settings
 from django.test import TestCase
 
 from edx_rest_framework_extensions.tests.factories import UserFactory
-from edx_rest_framework_extensions.utils import jwt_decode_handler
+from edx_rest_framework_extensions import utils
 
 
-def generate_jwt_token(payload):
-    """Generate a valid JWT token for authenticated requests."""
-    return jwt.encode(payload, settings.JWT_AUTH['JWT_SECRET_KEY']).decode('utf-8')
+def generate_jwt_token(payload, signing_key=None):
+    """
+    Generate a valid JWT token for authenticated requests.
+    """
+    signing_key = signing_key or settings.JWT_AUTH['JWT_ISSUERS'][0]['SECRET_KEY']
+    return jwt.encode(payload, signing_key).decode('utf-8')
 
 
 def generate_jwt_payload(user):
-    """Generate a valid JWT payload given a user."""
+    """
+    Generate a valid JWT payload given a user.
+    """
+    jwt_issuer_data = settings.JWT_AUTH['JWT_ISSUERS'][0]
     now = int(time())
     ttl = 5
     return {
-        'iss': settings.JWT_AUTH['JWT_ISSUER'],
-        'aud': settings.JWT_AUTH['JWT_AUDIENCE'],
+        'iss': jwt_issuer_data['ISSUER'],
+        'aud': jwt_issuer_data['AUDIENCE'],
         'username': user.username,
         'email': user.email,
         'iat': now,
@@ -29,6 +36,7 @@ def generate_jwt_payload(user):
     }
 
 
+@ddt.ddt
 class JWTDecodeHandlerTests(TestCase):
     """ Tests for the `jwt_decode_handler` utility function. """
     def setUp(self):
@@ -38,10 +46,46 @@ class JWTDecodeHandlerTests(TestCase):
         self.jwt = generate_jwt_token(self.payload)
 
     def test_decode_success(self):
-        self.assertDictEqual(jwt_decode_handler(self.jwt), self.payload)
+        """
+        Confirms that the format of the valid response from the token decoder matches the payload
+        """
+        self.assertDictEqual(utils.jwt_decode_handler(self.jwt), self.payload)
 
-    def test_decode_error(self):
+    @ddt.data(*settings.JWT_AUTH['JWT_ISSUERS'])
+    def test_decode_valid_token_multiple_valid_issuers(self, jwt_issuer):
+        """
+        Validates that a valid token is properly decoded given a list of multiple valid issuers
+        """
+
+        # Verify that each valid issuer is properly matched against the valid issuers list
+        # and used to decode the token that was generated using said valid issuer data
+        self.payload['iss'] = jwt_issuer['ISSUER']
+        token = generate_jwt_token(self.payload, jwt_issuer['SECRET_KEY'])
+        self.assertEqual(utils.jwt_decode_handler(token), self.payload)
+
+    def test_decode_failure(self):
+        """
+        Verifies the function logs decode failures, and raises an InvalidTokenError if the token cannot be decoded
+        """
+
+        # Create tokens using each invalid issuer and attempt to decode them against
+        # the valid issuers list, which won't work
         with mock.patch('edx_rest_framework_extensions.utils.logger') as patched_log:
             with self.assertRaises(jwt.InvalidTokenError):
-                jwt_decode_handler('not.a.valid.jwt')
-            patched_log.exception.assert_called_once_with('JWT decode failed!')
+                self.payload['iss'] = 'invalid-issuer'
+                signing_key = 'invalid-secret-key'
+                # Generate a token using the invalid issuer data
+                token = generate_jwt_token(self.payload, signing_key)
+                # Attempt to decode the token against the entries in the valid issuers list,
+                # which will fail with an InvalidTokenError
+                utils.jwt_decode_handler(token)
+
+            # Verify that the proper entries were written to the log file
+            msg = "Token decode failed for issuer 'test-issuer-1'"
+            patched_log.info.assert_any_call(msg, exc_info=True)
+
+            msg = "Token decode failed for issuer 'test-issuer-2'"
+            patched_log.info.assert_any_call(msg, exc_info=True)
+
+            msg = "All combinations of JWT issuers and secret keys failed to validate the token."
+            patched_log.error.assert_any_call(msg)

--- a/edx_rest_framework_extensions/utils.py
+++ b/edx_rest_framework_extensions/utils.py
@@ -2,7 +2,10 @@
 import logging
 
 import jwt
+from django.conf import settings
 from rest_framework_jwt.settings import api_settings
+
+from edx_rest_framework_extensions.settings import get_jwt_issuers
 
 logger = logging.getLogger(__name__)
 
@@ -12,8 +15,9 @@ def jwt_decode_handler(token):
     Decodes a JSON Web Token (JWT).
 
     Notes:
-        * Aids debugging by logging an exception if ``InvalidTokenError`` is raised when decoding fails.
         * Requires "exp" and "iat" claims to be present in the token's payload.
+        * Supports multiple issuer decoding via settings.JWT_AUTH['JWT_ISSUERS'] (see below)
+        * Aids debugging by logging DecodeError and InvalidTokenError log entries when decoding fails.
 
     Examples:
         Use with `djangorestframework-jwt <https://getblimp.github.io/django-rest-framework-jwt/>`_, by changing
@@ -23,7 +27,27 @@ def jwt_decode_handler(token):
 
             JWT_AUTH = {
                 'JWT_DECODE_HANDLER': 'edx_rest_framework_extensions.utils.jwt_decode_handler',
+                'JWT_ISSUER': 'https://the.jwt.issuer',
+                'JWT_SECRET_KEY': 'the-jwt-secret-key',  (defaults to settings.SECRET_KEY)
+                'JWT_AUDIENCE': 'the-jwt-audience',
             }
+
+        Enable multi-issuer support by specifying a list of dictionaries as settings.JWT_AUTH['JWT_ISSUERS']:
+
+        .. code-block:: python
+
+            JWT_ISSUERS = [
+                    {
+                        'ISSUER': 'test-issuer-1',
+                        'SECRET_KEY': 'test-secret-key-1',
+                        'AUDIENCE': 'test-audience-1',
+                    },
+                    {
+                        'ISSUER': 'test-issuer-2',
+                        'SECRET_KEY': 'test-secret-key-2',
+                        'AUDIENCE': 'test-audience-2',
+                    }
+                ]
 
     Args:
         token (str): JWT to be decoded.
@@ -38,21 +62,28 @@ def jwt_decode_handler(token):
 
     options = {
         'verify_exp': api_settings.JWT_VERIFY_EXPIRATION,
+        'verify_aud': settings.JWT_AUTH['JWT_VERIFY_AUDIENCE'],
         'require_exp': True,
         'require_iat': True,
     }
 
-    try:
-        return jwt.decode(
-            token,
-            api_settings.JWT_SECRET_KEY,
-            api_settings.JWT_VERIFY,
-            options=options,
-            leeway=api_settings.JWT_LEEWAY,
-            audience=api_settings.JWT_AUDIENCE,
-            issuer=api_settings.JWT_ISSUER,
-            algorithms=[api_settings.JWT_ALGORITHM]
-        )
-    except jwt.InvalidTokenError:
-        logger.exception('JWT decode failed!')
-        raise
+    for jwt_issuer in get_jwt_issuers():
+        try:
+            decoded = jwt.decode(
+                token,
+                jwt_issuer['SECRET_KEY'],
+                api_settings.JWT_VERIFY,
+                options=options,
+                leeway=api_settings.JWT_LEEWAY,
+                audience=jwt_issuer['AUDIENCE'],
+                issuer=jwt_issuer['ISSUER'],
+                algorithms=[api_settings.JWT_ALGORITHM]
+            )
+            return decoded
+        except jwt.DecodeError:
+            msg = "Token decode failed for issuer '{issuer}'".format(issuer=jwt_issuer['ISSUER'])
+            logger.info(msg, exc_info=True)
+
+    msg = 'All combinations of JWT issuers and secret keys failed to validate the token.'
+    logger.error(msg)
+    raise jwt.InvalidTokenError(msg)

--- a/test_settings.py
+++ b/test_settings.py
@@ -29,8 +29,35 @@ TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 EDX_DRF_EXTENSIONS = {}
 
+# USER_SETTINGS overrides for djangorestframework-jwt APISettings class
+# See https://github.com/GetBlimp/django-rest-framework-jwt/blob/master/rest_framework_jwt/settings.py
 JWT_AUTH = {
+
     'JWT_AUDIENCE': 'test-aud',
+
+    'JWT_DECODE_HANDLER': 'edx_rest_framework_extensions.utils.jwt_decode_handler',
+
     'JWT_ISSUER': 'test-iss',
-    'JWT_SECRET_KEY': 'tell-no-one',
+
+    'JWT_LEEWAY': 1,
+
+    'JWT_SECRET_KEY': 'test-key',
+
+    'JWT_VERIFY_AUDIENCE': False,
+
+    'JWT_VERIFY_EXPIRATION': True,
+
+    # JWT_ISSUERS enables token decoding for multiple issuers (Note: This is not a native DRF-JWT field)
+    'JWT_ISSUERS': [
+        {
+            'ISSUER': 'test-issuer-1',
+            'SECRET_KEY': 'test-secret-key-1',
+            'AUDIENCE': 'test-audience-1',
+        },
+        {
+            'ISSUER': 'test-issuer-2',
+            'SECRET_KEY': 'test-secret-key-2',
+            'AUDIENCE': 'test-audience-2',
+        }
+    ],
 }


### PR DESCRIPTION
@clintonb @mjfrey -- here's a first attempt at getting multiple issuers up and running -- it uses the nested for-loop approach, which we can certainly refactor, but I wanted to start from a working example instead of blazing a new trail since I'm not entirely familiar with JWT or this particular code project.