### PR TITLE
mattdrayer/catch-token-exception: Also handle InvalidTokenError

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '1.1.0'  # pragma: no cover
+__version__ = '1.1.1'  # pragma: no cover

--- a/edx_rest_framework_extensions/tests/test_utils.py
+++ b/edx_rest_framework_extensions/tests/test_utils.py
@@ -89,3 +89,25 @@ class JWTDecodeHandlerTests(TestCase):
 
             msg = "All combinations of JWT issuers and secret keys failed to validate the token."
             patched_log.error.assert_any_call(msg)
+
+    def test_decode_failure_invalid_token(self):
+        """
+        Verifies the function logs decode failures, and raises an InvalidTokenError if the token cannot be decoded
+        """
+
+        # Create tokens using each invalid issuer and attempt to decode them against
+        # the valid issuers list, which won't work
+        with mock.patch('edx_rest_framework_extensions.utils.logger') as patched_log:
+            with self.assertRaises(jwt.InvalidTokenError):
+                # Attempt to decode an invalid token, which will fail with an InvalidTokenError
+                utils.jwt_decode_handler("invalid.token")
+
+            # Verify that the proper entries were written to the log file
+            msg = "Token decode failed for issuer 'test-issuer-1'"
+            patched_log.info.assert_any_call(msg, exc_info=True)
+
+            msg = "Token decode failed for issuer 'test-issuer-2'"
+            patched_log.info.assert_any_call(msg, exc_info=True)
+
+            msg = "All combinations of JWT issuers and secret keys failed to validate the token."
+            patched_log.error.assert_any_call(msg)

--- a/edx_rest_framework_extensions/utils.py
+++ b/edx_rest_framework_extensions/utils.py
@@ -80,7 +80,7 @@ def jwt_decode_handler(token):
                 algorithms=[api_settings.JWT_ALGORITHM]
             )
             return decoded
-        except jwt.DecodeError:
+        except jwt.InvalidTokenError:
             msg = "Token decode failed for issuer '{issuer}'".format(issuer=jwt_issuer['ISSUER'])
             logger.info(msg, exc_info=True)
 


### PR DESCRIPTION
@clintonb @douglashall @e0d -- added InvalidTokenError to the list of exceptions we watch for during JWT decoding.