### PR TITLE
Don't change warnings global settings

### DIFF
--- a/edx_rest_framework_extensions/settings.py
+++ b/edx_rest_framework_extensions/settings.py
@@ -56,7 +56,6 @@ def _get_deprecated_jwt_issuers():
     Having this allows for easier testing/mocking
     """
     # If JWT_ISSUERS is not defined, attempt to return the deprecated settings.
-    warnings.simplefilter('default')
     warnings.warn(
         "'JWT_ISSUERS' list not defined, checking for deprecated settings.",
         DeprecationWarning

--- a/edx_rest_framework_extensions/tests/test_settings.py
+++ b/edx_rest_framework_extensions/tests/test_settings.py
@@ -50,8 +50,8 @@ class SettingsTests(TestCase):
         mock_call = 'edx_rest_framework_extensions.settings._get_current_jwt_issuers'
         with mock.patch(mock_call, mock.Mock(return_value=None)):
             with warnings.catch_warnings(record=True) as warning_list:
-                self.assertEqual(get_jwt_issuers(), _deprecated)
                 warnings.simplefilter("default")
+                self.assertEqual(get_jwt_issuers(), _deprecated)
                 self.assertEqual(len(warning_list), 1)
                 self.assertTrue(issubclass(warning_list[-1].category, DeprecationWarning))
                 msg = "'JWT_ISSUERS' list not defined, checking for deprecated settings."


### PR DESCRIPTION
This line was causing test failures elsewhere in the edx-platform test suite, when warnings were appearing that shouldn't.
@clintonb @mattdrayer Do you know why this line is here? A library function like this shouldn't be changing the global warnings settings.
/cc @gsong 