### PR TITLE
adding openedx.yaml

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,0 +1,8 @@
+# This file describes this Open edX repo, as described in OEP-2:
+# http://open-edx-proposals.readthedocs.io/en/latest/oep-0002-bp-repo-metadata.html#specification
+
+nick: drfx
+oeps: {}
+openedx-release: {ref: release}
+owner: edx/platform-team
+track-pulls: true

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -3,6 +3,5 @@
 
 nick: drfx
 oeps: {}
-openedx-release: {ref: release}
 owner: edx/platform-team
 track-pulls: true


### PR DESCRIPTION
This is only adding the openedx.yaml file that our bot uses to help manage OSPRs. Just for transparency, tests did not completely pass:

  py27-django18: commands succeeded
  py27-django19: commands succeeded
  py27-django110: commands succeeded
  py27-django111: commands succeeded
  py35-django18: commands succeeded
  py35-django19: commands succeeded
  py35-django110: commands succeeded
  py35-django111: commands succeeded
  py36-django111: commands succeeded
ERROR:   quality: commands failed
  docs: commands succeeded

Let me know if that is an issue.
