### PR TITLE
Middleware to ensure JwtHasScope permission for JWT Authentication

### DIFF
--- a/edx_rest_framework_extensions/middleware.py
+++ b/edx_rest_framework_extensions/middleware.py
@@ -1,0 +1,46 @@
+"""
+Middleware to ensure best practices of DRF endpoints.
+"""
+import logging
+
+from rest_framework_jwt.authentication import BaseJSONWebTokenAuthentication
+
+from .permissions import JwtHasScope
+
+log = logging.getLogger(__name__)
+
+
+class EnsureJWTAuthSettingsMiddleware(object):
+    """
+    Django middleware object that ensures the proper Permission classes
+    are set on all endpoints that use JWTAuthentication.
+    """
+    _required_permission_classes = (JwtHasScope,)
+
+    def _includes_base_class(self, iter_classes, base_class):
+        """
+        Returns whether any class in iter_class is a subclass of the given base_class.
+        """
+        return any(
+            issubclass(auth_class, base_class) for auth_class in iter_classes,
+        )
+
+    def process_view(self, request, view_func, view_args, view_kwargs):  # pylint: disable=unused-argument
+        view_class = getattr(view_func, 'view_class', view_func)
+
+        view_authentication_classes = getattr(view_class, 'authentication_classes', tuple())
+        if self._includes_base_class(view_authentication_classes, BaseJSONWebTokenAuthentication):
+
+            view_permission_classes = getattr(view_class, 'permission_classes', tuple())
+
+            for perm_class in self._required_permission_classes:
+
+                if not self._includes_base_class(view_permission_classes, perm_class):
+                    log.warning(
+                        u"The view %s allows Jwt Authentication but needs to include the %s permission class.",
+                        view_class.__name__,
+                        perm_class.__name__,
+                    )
+
+            view_class.permission_classes = view_permission_classes
+            view_class.permission_classes += self._required_permission_classes

--- a/edx_rest_framework_extensions/permissions.py
+++ b/edx_rest_framework_extensions/permissions.py
@@ -40,8 +40,7 @@ class JwtHasScope(BasePermission):
         try:
             return getattr(view, 'required_scopes')
         except AttributeError:
-            raise ImproperlyConfigured(
-                'TokenHasScope requires the view to define the required_scopes attribute')
+            raise ImproperlyConfigured('JwtHasScope requires the view to define the required_scopes attribute')
 
 
 class JwtHasContentOrgFilterForRequestedCourse(BasePermission):

--- a/edx_rest_framework_extensions/tests/test_middleware.py
+++ b/edx_rest_framework_extensions/tests/test_middleware.py
@@ -1,0 +1,99 @@
+"""
+Unit tests for safe_endpoints Middleware.
+"""
+import ddt
+from itertools import product
+from mock import patch
+
+from django.test import TestCase, RequestFactory
+from rest_framework.authentication import SessionAuthentication
+from rest_framework_jwt.authentication import BaseJSONWebTokenAuthentication
+from rest_framework.decorators import api_view
+from rest_framework.views import APIView
+
+from ..middleware import EnsureJWTAuthSettingsMiddleware
+from ..permissions import JwtHasScope
+
+
+class SomeIncludedPermissionClass(object):
+    pass
+
+
+class SomeJwtAuthenticationSubclass(BaseJSONWebTokenAuthentication):
+    pass
+
+
+def some_auth_decorator(include_jwt_auth=True, include_required_perm=True):
+    def _decorator(f):
+        f.permission_classes = (SomeIncludedPermissionClass,)
+        f.authentication_classes = (SessionAuthentication,)
+        if include_jwt_auth:
+            f.authentication_classes += (SomeJwtAuthenticationSubclass,)
+        if include_required_perm:
+            f.permission_classes += (JwtHasScope,)
+        return f
+    return _decorator
+
+
+@ddt.ddt
+class TestEnsureJWTAuthSettingsMiddleware(TestCase):
+    def setUp(self):
+        super(TestEnsureJWTAuthSettingsMiddleware, self).setUp()
+        self.request = RequestFactory().get('/')
+        self.middleware = EnsureJWTAuthSettingsMiddleware()
+
+    def _assert_included(self, item, iterator, should_be_included):
+        if should_be_included:
+            self.assertIn(item, iterator)
+        else:
+            self.assertNotIn(item, iterator)
+
+    @ddt.data(
+        *product(
+            (True, False),
+            (True, False),
+            (True, False),
+        )
+    )
+    @ddt.unpack
+    def test_api_views(self, use_function_view, include_jwt_auth, include_required_perm):
+        @some_auth_decorator(include_jwt_auth=include_jwt_auth, include_required_perm=include_required_perm)
+        class SomeClassView(APIView):
+            pass
+
+        @api_view(["GET"])
+        @some_auth_decorator(include_jwt_auth=include_jwt_auth, include_required_perm=include_required_perm)
+        def some_function_view(request):
+            pass
+
+        view = some_function_view if use_function_view else SomeClassView
+        view_class = view.view_class if use_function_view else view
+
+        self._assert_included(
+            SomeJwtAuthenticationSubclass,
+            view_class.authentication_classes,
+            should_be_included=include_jwt_auth,
+        )
+
+        with patch('edx_rest_framework_extensions.middleware.log.warning') as mock_warning:
+            self.assertIsNone(
+                self.middleware.process_view(self.request, view, None, None)
+            )
+            self.assertEqual(mock_warning.called, include_jwt_auth and not include_required_perm)
+
+        self._assert_included(
+            JwtHasScope,
+            view_class.permission_classes,
+            should_be_included=include_required_perm or include_jwt_auth,
+        )
+
+    def test_simple_view(self):
+        """
+        Verify middleware works for views that don't have an api_view decorator.
+        """
+        def some_simple_view(request):
+            pass
+
+        self.assertIsNone(
+            self.middleware.process_view(self.request, some_simple_view, None, None)
+        )

--- a/edx_rest_framework_extensions/tests/test_permission.py
+++ b/edx_rest_framework_extensions/tests/test_permission.py
@@ -5,7 +5,6 @@ from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ImproperlyConfigured
 from django.test import RequestFactory, TestCase
 from mock import Mock, patch
-from rest_framework.exceptions import PermissionDenied
 from rest_framework.views import APIView
 
 from edx_rest_framework_extensions.tests.factories import UserFactory
@@ -15,7 +14,6 @@ from edx_rest_framework_extensions.permissions import (
     JwtHasContentOrgFilterForRequestedCourse,
     JwtHasScope,
 )
-from edx_rest_framework_extensions.decorators import SWITCH_ENFORCE_JWT_SCOPES
 from edx_rest_framework_extensions.tests import factories
 from edx_rest_framework_extensions.tests.test_utils import generate_jwt
 

--- a/edx_rest_framework_extensions/utils.py
+++ b/edx_rest_framework_extensions/utils.py
@@ -12,7 +12,6 @@ DEFAULT_JWT_SUPPORTED_VERSION = '1.0.0'
 logger = logging.getLogger(__name__)
 
 
-
 def jwt_decode_handler(token):
     """
     Decodes a JSON Web Token (JWT).
@@ -106,6 +105,7 @@ def verify_jwt_version(decoded_token):
     if jwt_version.major > supported_version.major:
         logger.info('Token decode failed due to unsupported JWT version number [%s]', str(jwt_version))
         raise jwt.InvalidTokenError
+
 
 def decode_jwt_scopes(token):
     """


### PR DESCRIPTION
This PR introduces a Middleware as a [runway](http://www.scaledagileframework.com/architectural-runway/) for [enforcing OAuth scopes](https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0006-enforce-scopes-in-LMS-APIs.rst).

The Middleware updates any REST API views that use `JwtAuthentication` to always use the new JwtHasScope permission class.

This is needed because the Django framework doesn't allow us to configure `Permission` classes that *must* be enforced by all endpoints.  Although it supports a [DEFAULT_PERMISSION_CLASSES](http://www.django-rest-framework.org/api-guide/permissions/#setting-the-permission-policy) setting, any endpoint can choose to override and not use the defaults.  By having a middleware, we can update permission classes for all endpoints at runtime.

In the future, we may also introduce a decorator for all endpoints to use with a static linter that provides more immediate feedback to developers - rather than updating permissions behind-the-scenes with a middleware.
