### PR TITLE
Handle ConditionalPermission in middleware.

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '1.5.0'  # pragma: no cover
+__version__ = '1.5.1'  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         'semantic_version',
         'python-dateutil>=2.0',
         'requests>=2.7.0,<3.0.0',
+        'rest-condition>=1.0.3,<2.0',
         'six',
     ]
 )


### PR DESCRIPTION
EnsureJWTAuthSettingsMiddleware's check for permissions classes would
fail if it was applied to a view that uses conditional permissions from
the rest_condition library, like:

    C(permissions.IsStaff) | permissions.IsUserInUrl

The cause of failure is that we were checking for subclasses of
particular permissions like IsStaff, and ConditionalPermissions are
outside of that hierarchy (and aren't even classes). This is one of the
contributing issues in ARCH-153.

This commit checks to see if a permission is a ConditionalPermission
and then expands it out so that we capture only the Permission classes
inside. So the check will pass as long as you have the required
permission class _somewhere_ in your view's permissions, with the
assumption being that if you're using the required permission in a
Conditional, you probably know what you're doing and we shouldn't
blindly append the required permission class at the end.