### PR TITLE
Update Permissions and JWT handling for OAuth Scopes

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '1.5.1'  # pragma: no cover
+__version__ = '1.5.2'  # pragma: no cover

--- a/edx_rest_framework_extensions/authentication.py
+++ b/edx_rest_framework_extensions/authentication.py
@@ -220,8 +220,9 @@ def is_jwt_authenticated(request):
         BaseJSONWebTokenAuthentication,
     )
     if is_jwt_authenticated:
-        assert(
-            getattr(request, 'auth', None),
-            'Unexpected error: Used JwtAuthentication, but the request auth attribute was not populated with the JWT.'
-        )
+        if not getattr(request, 'auth', None):
+            logger.error(
+                'Unexpected error: Used JwtAuthentication, but the request auth attribute was not populated with the JWT.'
+            )
+            return False
     return is_jwt_authenticated

--- a/edx_rest_framework_extensions/config.py
+++ b/edx_rest_framework_extensions/config.py
@@ -2,4 +2,6 @@
 Application configuration constants and code.
 """
 
-SWITCH_ENFORCE_JWT_SCOPES = 'oauth2.enforce_jwt_scopes'
+NAMESPACE_SWITCH = 'oauth2'
+SWITCH_ENFORCE_JWT_SCOPES = 'enforce_jwt_scopes'
+NAMESPACED_SWITCH_ENFORCE_JWT_SCOPES = '{}.{}'.format(NAMESPACE_SWITCH, SWITCH_ENFORCE_JWT_SCOPES)

--- a/edx_rest_framework_extensions/permissions.py
+++ b/edx_rest_framework_extensions/permissions.py
@@ -1,12 +1,18 @@
 """ Permission classes. """
+import logging
 from django.core.exceptions import ImproperlyConfigured
 from opaque_keys.edx.keys import CourseKey
-from rest_framework.permissions import BasePermission
+from rest_condition import C
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.permissions import BasePermission, IsAuthenticated
 import waffle
 
 from edx_rest_framework_extensions.authentication import is_jwt_authenticated
-from edx_rest_framework_extensions.config import SWITCH_ENFORCE_JWT_SCOPES
-from edx_rest_framework_extensions.jwt_decoder import decode_jwt_filters, decode_jwt_scopes
+from edx_rest_framework_extensions.config import NAMESPACED_SWITCH_ENFORCE_JWT_SCOPES
+from edx_rest_framework_extensions.jwt_decoder import decode_jwt_filters, decode_jwt_scopes, decode_jwt_is_restricted
+
+
+log = logging.getLogger(__name__)
 
 
 class IsSuperuser(BasePermission):
@@ -29,20 +35,33 @@ class IsUserInUrl(BasePermission):
     Allows access if the requesting user matches the user in the URL.
     """
     def has_permission(self, request, view):
-        user_parameter_name = 'username'
-        url_username = (
-            request.GET.get(user_parameter_name, '') or
-            getattr(request, 'parser_context', {}).get('kwargs', {}).get(user_parameter_name, '')
-        )
-        return request.user.username.lower() == url_username.lower()
+        allowed = request.user.username.lower() == _get_username_param(request)
+        if not allowed:
+            log.info(u"Permission IsUserInUrl: not satisfied for requesting user %s.", request.user.username)
+        return allowed
 
 
-class IsJwtAuthenticated(BasePermission):
+class JwtRestrictedApplication(BasePermission):
     """
-    Returns whether the request was successfully authenticated with JwtAuthentication.
+    Returns whether the request was successfully authenticated with JwtAuthentication
+    by a RestrictedApplication.
     """
+    message = 'Not a Restricted JWT Application.'
+
     def has_permission(self, request, view):
-        return is_jwt_authenticated(request)
+        return self.is_enforced_and_jwt_restricted_app(request)
+
+    @classmethod
+    def is_enforced_and_jwt_restricted_app(cls, request):
+        is_enforcement_enabled = waffle.switch_is_active(NAMESPACED_SWITCH_ENFORCE_JWT_SCOPES)
+        ret_val = is_enforcement_enabled and is_jwt_authenticated(request) and decode_jwt_is_restricted(request.auth)
+        log.debug(u"Permission JwtRestrictedApplication: returns %s.", ret_val)
+        return ret_val
+
+
+class NotJwtRestrictedApplication(BasePermission):
+    def has_permission(self, request, view):
+        return not JwtRestrictedApplication.is_enforced_and_jwt_restricted_app(request)
 
 
 class JwtHasScope(BasePermission):
@@ -52,22 +71,16 @@ class JwtHasScope(BasePermission):
     message = 'JWT missing required scopes.'
 
     def has_permission(self, request, view):
-        if _should_skip_jwt_scope_enforcement(request):
-            return True
         jwt_scopes = decode_jwt_scopes(request.auth)
-        required_scopes = set(self.get_scopes(request, view))
-        if required_scopes.issubset(jwt_scopes):
-            return True
-        return False
-
-    def get_scopes(self, request, view):
-        """
-        Return the required scopes defined on the view.
-        """
-        try:
-            return getattr(view, 'required_scopes')
-        except AttributeError:
-            raise ImproperlyConfigured('JwtHasScope requires the view to define the required_scopes attribute')
+        required_scopes = set(getattr(view, 'required_scopes', []))
+        allowed = bool(required_scopes) and required_scopes.issubset(jwt_scopes)
+        if not allowed:
+            log.warning(
+                u"Permission JwtHasScope: required scopes '%s' are not a subset of the token's scopes '%s'.",
+                required_scopes,
+                jwt_scopes,
+            )
+        return allowed
 
 
 class JwtHasContentOrgFilterForRequestedCourse(BasePermission):
@@ -83,21 +96,69 @@ class JwtHasContentOrgFilterForRequestedCourse(BasePermission):
         of the organizations specified in the content provider filters
         in the JWT used to authenticate.
         """
-        if _should_skip_jwt_scope_enforcement(request):
-            return True
         course_key = CourseKey.from_string(view.kwargs.get('course_id'))
         jwt_filters = decode_jwt_filters(request.auth)
-        for provider_type, filter_value in jwt_filters:
-            if provider_type == 'content_org' and filter_value == course_key.org:
+        for filter_type, filter_value in jwt_filters:
+            if filter_type == 'content_org' and filter_value == course_key.org:
                 return True
+        log.warning(
+            u"Permission JwtHasContentOrgFilterForRequestedCourse: no filter found for %s.",
+            course_key.org,
+        )
         return False
 
 
-def _should_skip_jwt_scope_enforcement(request):
+class JwtHasUserFilterForRequestedUser(BasePermission):
     """
-    Returns True if either the request is not JWT authenticated or if
-    JWT scopes enforcement is disabled.
+    The JWT used to authenticate contains the appropriate user filter for the
+    requested user resource.
     """
-    if not is_jwt_authenticated(request):
-        return True
-    return not waffle.switch_is_active(SWITCH_ENFORCE_JWT_SCOPES)
+    message = 'JWT missing required user filter.'
+
+    def has_permission(self, request, view):
+        """
+        If the JWT has a user filter, verify that the filtered
+        user value matches the user in the URL.
+        """
+        user_filter = self._get_user_filter(request)
+        if not user_filter:
+            # no user filters are present in the token to limit access
+            return True
+
+        username_param = _get_username_param(request)
+        allowed = user_filter == username_param
+        if not allowed:
+            log.warning(
+                u"Permission JwtHasUserFilterForRequestedUser: user_filter %s doesn't match username %s.",
+                user_filter,
+                username_param,
+            )
+        return allowed
+
+    def _get_user_filter(self, request):
+        jwt_filters = decode_jwt_filters(request.auth)
+        for filter_type, filter_value in jwt_filters:
+            if filter_type == 'user':
+                if filter_value == 'me':
+                    filter_value = request.user.username.lower()
+                return filter_value
+        return None
+
+
+_NOT_JWT_RESTRICTED_PERMISSIONS = C(NotJwtRestrictedApplication) & (C(IsStaff) | IsUserInUrl)
+_JWT_RESTRICTED_PERMISSIONS = (
+    C(JwtRestrictedApplication) &
+    JwtHasScope &
+    JwtHasContentOrgFilterForRequestedCourse &
+    JwtHasUserFilterForRequestedUser
+)
+JWT_RESTRICTED_APPLICATION_OR_USER_ACCESS = C(IsAuthenticated) & (_NOT_JWT_RESTRICTED_PERMISSIONS | _JWT_RESTRICTED_PERMISSIONS)
+
+
+def _get_username_param(request):
+    user_parameter_name = 'username'
+    url_username = (
+        getattr(request, 'parser_context', {}).get('kwargs', {}).get(user_parameter_name, '') or
+        request.GET.get(user_parameter_name, '')
+    )
+    return url_username.lower()

--- a/edx_rest_framework_extensions/tests/test_permissions.py
+++ b/edx_rest_framework_extensions/tests/test_permissions.py
@@ -1,10 +1,14 @@
 """ Tests for permission classes. """
 
+from collections import namedtuple
+
 import ddt
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ImproperlyConfigured
 from django.test import RequestFactory, TestCase
+from itertools import product
 from mock import Mock, patch
+from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.authentication import SessionAuthentication
 from rest_framework_jwt.authentication import BaseJSONWebTokenAuthentication
@@ -21,16 +25,14 @@ class IsSuperuserTests(TestCase):
     """ Tests for the IsSuperuser permission class. """
 
     @ddt.data(True, False)
-    def test_has_permission(self, has_permission):
-        """ Verify the method only returns True if the user is a superuser. """
+    def test_superuser_has_permission(self, has_permission):
         request = RequestFactory().get('/')
         request.user = factories.UserFactory(is_superuser=has_permission)
         permission = permissions.IsSuperuser()
         self.assertEqual(permission.has_permission(request, None), has_permission)
 
     @ddt.data(None, AnonymousUser())
-    def test_has_permission_with_invalid_users(self, user):
-        """ Verify the method returns False if the request's user is not a real user. """
+    def test_invalid_user_has_no_permission(self, user):
         request = RequestFactory().get('/')
         request.user = user
         permission = permissions.IsSuperuser()
@@ -52,31 +54,80 @@ class IsStaffTests(TestCase):
 class IsUserInUrlTests(TestCase):
     """ Tests for the IsUserInUrl permission class. """
 
-    @ddt.data(True, False)
-    def test_has_permission(self, has_user_in_url):
-        user = factories.UserFactory(username='foo')
+    def _create_request(self, user, username_in_param=None, username_in_resource=None):
         url = '/'
-        if has_user_in_url:
-            url += '?username={}'.format(user.username)
+        if username_in_param:
+            url += '?username={}'.format(username_in_param)
         request = RequestFactory().get(url)
         request.user = user
+        if username_in_resource:
+            request.parser_context = dict(kwargs=dict(username=username_in_resource))
+        return request
+
+    @ddt.data(True, False)
+    def test_user_in_url_param(self, has_user_in_url):
+        user = factories.UserFactory(username='this_user')
+        request = self._create_request(
+            user,
+            username_in_param=user.username if has_user_in_url else 'another_user',
+        )
         self.assertEqual(permissions.IsUserInUrl().has_permission(request, None), has_user_in_url)
+
+    @ddt.data(True, False)
+    def test_user_in_url_resource(self, has_user_in_resource):
+        user = factories.UserFactory(username='this_user')
+        request = self._create_request(
+            user,
+            username_in_resource=user.username if has_user_in_resource else 'another_user',
+        )
+        self.assertEqual(permissions.IsUserInUrl().has_permission(request, None), has_user_in_resource)
+
+    def test_resource_takes_precedence_over_param(self):
+        user = factories.UserFactory(username='this_user')
+        request = self._create_request(
+            user,
+            username_in_resource='another_user',
+            username_in_param='this_user',
+        )
+        self.assertFalse(permissions.IsUserInUrl().has_permission(request, None))
+
+        request = self._create_request(
+            user,
+            username_in_resource='this_user',
+            username_in_param='another_user',
+        )
+        self.assertTrue(permissions.IsUserInUrl().has_permission(request, None))
 
 
 @ddt.ddt
-class IsJwtAuthenticatedTests(TestCase):
-    """ Tests for the IsJwtAuthenticated permission class. """
+class JwtApplicationPermissionsTests(TestCase):
+    """ Tests for the JwtRestrictedApplication and NotJwtRestrictedApplication permission classes. """
 
-    @ddt.data(JwtAuthentication, BaseJSONWebTokenAuthentication, SessionAuthentication, None)
-    def test_has_permission(self, authentication_class):
+    @patch('edx_rest_framework_extensions.permissions.waffle.switch_is_active')
+    @ddt.data(
+        *product(
+            (permissions.JwtRestrictedApplication, permissions.NotJwtRestrictedApplication),
+            (JwtAuthentication, BaseJSONWebTokenAuthentication, SessionAuthentication, None),
+            (True, False),
+            (True, False),
+        )
+    )
+    @ddt.unpack
+    def test_has_permission(self, permission_class, authentication_class, is_restricted, enforce_scopes, waffle_mock):
+        waffle_mock.return_value = enforce_scopes
         request = RequestFactory().get('/')
         request.successful_authenticator = authentication_class() if authentication_class else None
         request.user = factories.UserFactory()
-        request.auth = generate_jwt(request.user)
-        self.assertEqual(
-            permissions.IsJwtAuthenticated().has_permission(request, None),
-            issubclass(type(request.successful_authenticator), BaseJSONWebTokenAuthentication),
-        )
+        request.auth = generate_jwt(request.user, is_restricted=is_restricted)
+
+        is_jwt_auth_subclass = issubclass(type(request.successful_authenticator), BaseJSONWebTokenAuthentication)
+
+        has_permission = permission_class().has_permission(request, view=None)
+        expected_restricted_permission = enforce_scopes and is_restricted and is_jwt_auth_subclass
+        if permission_class == permissions.JwtRestrictedApplication:
+            self.assertEqual(has_permission, expected_restricted_permission)
+        else:
+            self.assertEqual(has_permission, not expected_restricted_permission)
 
 
 @ddt.ddt
@@ -87,40 +138,24 @@ class JwtHasScopeTests(TestCase):
         self.user = UserFactory()
 
     @ddt.data(
-        (True, JwtAuthentication(), ('test:read',), ('test:read',), True),
-        (True, JwtAuthentication(), ('test:write'), ('test:read',), False),
-        (True, JwtAuthentication(), (), ('test:read',), False),
-        (True, None, (), ('test:read'), True),
-        (False, JwtAuthentication(), (), ('test:read'), True),
-        (False, None, (), ('test:read'), True),
+        (JwtAuthentication(), ('test:read',), ('test:read',), True),  # match
+        (JwtAuthentication(), ('test:write'), ('test:read',), False),  # mismatch
+        (JwtAuthentication(), ('test:read'), (), False),  # empty on API
+        (JwtAuthentication(), ('test:read'), None, False),  # missing on API
+        (JwtAuthentication(), (), ('test:read',), False),  # missing on jwt
+        (JwtAuthentication(), (), None, False),  # missing on both
+        (None, (), ('test:read'), False),  # no auth
     )
     @ddt.unpack
-    @patch('edx_rest_framework_extensions.permissions.waffle.switch_is_active')
-    def test_has_permission(self, enforce_scopes, authentication_class, jwt_scopes,
-                            required_scopes, expected_result, waffle_mock):
-        """
-        Test that the permission check returns the expected result when scopes are validated.
-        """
-        waffle_mock.return_value = enforce_scopes
+    def test_has_permission(self, authentication_class, jwt_scopes, required_scopes, expected_result):
         request = RequestFactory().get('/')
         request.successful_authenticator = authentication_class
         request.auth = generate_jwt(self.user, scopes=jwt_scopes)
-        view = Mock(required_scopes=required_scopes)
+        if required_scopes is None:
+            view = APIView()
+        else:
+            view = Mock(required_scopes=required_scopes)
         self.assertEqual(permissions.JwtHasScope().has_permission(request, view), expected_result)
-
-    @patch('edx_rest_framework_extensions.permissions.waffle.switch_is_active')
-    def test_has_permission_missing_required_scopes(self, waffle_mock):
-        """
-        Test that the permission check raises an exception if
-        required_scopes was not defined on the view.
-        """
-        waffle_mock.return_value = True
-        request = RequestFactory().get('/')
-        request.successful_authenticator = JwtAuthentication()
-        request.auth = generate_jwt(self.user, scopes=['test:read'])
-        view = APIView()
-        with self.assertRaises(ImproperlyConfigured):
-            permissions.JwtHasScope().has_permission(request, view)
 
 
 @ddt.ddt
@@ -131,22 +166,14 @@ class JwtHasContentOrgFilterForRequestedCourseTests(TestCase):
         self.user = UserFactory()
 
     @ddt.data(
-        (True, JwtAuthentication(), ['content_org:edX'], {'course_id': 'course-v1:edX+DemoX+Demo_Course'}, True),
-        (True, JwtAuthentication(), ['content_org:TestX'], {'course_id': 'course-v1:edX+DemoX+Demo_Course'}, False),
-        (True, JwtAuthentication(), ['test:TestX'], {'course_id': 'course-v1:edX+DemoX+Demo_Course'}, False),
-        (True, JwtAuthentication(), [], {'course_id': 'course-v1:edX+DemoX+Demo_Course'}, False),
-        (True, None, [], {'course_id': 'course-v1:edX+DemoX+Demo_Course'}, True),
-        (False, JwtAuthentication(), [], {'course_id': 'course-v1:edX+DemoX+Demo_Course'}, True),
-        (False, None, [], {'course_id': 'course-v1:edX+DemoX+Demo_Course'}, True),
+        (JwtAuthentication(), ['content_org:edX'], {'course_id': 'course-v1:edX+DemoX+Demo_Course'}, True),
+        (JwtAuthentication(), ['content_org:TestX'], {'course_id': 'course-v1:edX+DemoX+Demo_Course'}, False),
+        (JwtAuthentication(), ['test:TestX'], {'course_id': 'course-v1:edX+DemoX+Demo_Course'}, False),
+        (JwtAuthentication(), [], {'course_id': 'course-v1:edX+DemoX+Demo_Course'}, False),
+        (None, [], {'course_id': 'course-v1:edX+DemoX+Demo_Course'}, False),
     )
     @ddt.unpack
-    @patch('edx_rest_framework_extensions.permissions.waffle.switch_is_active')
-    def test_has_permission(self, enforce_scopes, authentication_class, jwt_filters,
-                            view_kwargs, expected_result, waffle_mock):
-        """
-        Test that the permission check returns the expected result when scopes are validated.
-        """
-        waffle_mock.return_value = enforce_scopes
+    def test_has_permission(self, authentication_class, jwt_filters, view_kwargs, expected_result):
         request = RequestFactory().get('/')
         request.successful_authenticator = authentication_class
         request.auth = generate_jwt(self.user, filters=jwt_filters)
@@ -155,3 +182,176 @@ class JwtHasContentOrgFilterForRequestedCourseTests(TestCase):
             permissions.JwtHasContentOrgFilterForRequestedCourse().has_permission(request, view),
             expected_result,
         )
+
+
+@ddt.ddt
+class JwtHasUserFilterForRequestedUserTests(TestCase):
+    """ Tests for JwtHasUserFilterForRequestedUserTests permission class. """
+
+    def _create_request(self, user_filters, requested_username):
+        url = '/?username={}'.format(requested_username)
+        request = RequestFactory().get(url)
+        request.user = UserFactory(username='this_user')
+        request.auth = generate_jwt(request.user, filters=user_filters)
+        return request
+
+    @ddt.data(
+        # no user filters
+        ([], 'this_user', True),
+        ([], 'another_user', True),
+
+        # accessing self
+        (['user:me'], 'this_user', True),
+        (['user:this_user'], 'this_user', True),
+
+        # accessing another
+        (['user:me'], 'another_user', False),
+        (['user:this_user'], 'another_user', False),
+        (['user:another_user'], 'another_user', True),
+    )
+    @ddt.unpack
+    def test_has_permission(self, user_filters, requested_username, expected_result):
+        request = self._create_request(user_filters, requested_username)
+        self.assertEqual(
+            permissions.JwtHasUserFilterForRequestedUser().has_permission(request, None),
+            expected_result,
+        )
+
+
+@ddt.ddt
+class JwtRestrictionApplicationOrUserAccessTests(TestCase):
+    ExpectedLog = namedtuple('ExpectedLog', 'method, text, param')
+
+    IsUserInUrlLog = ExpectedLog('info', 'IsUserInUrl', None)
+    JwtIsUnrestrictedLog = ExpectedLog('debug', 'JwtRestrictedApplication', False)
+    JwtIsRestrictedLog = ExpectedLog('debug', 'JwtRestrictedApplication', True)
+    JwtHasScopeLog = ExpectedLog('warning', 'JwtHasScope', None)
+    JwtOrgFilterLog = ExpectedLog('warning', 'JwtHasContentOrgFilterForRequestedCourse', None)
+
+    class SomeClassView(APIView):
+        authentication_classes = (JwtAuthentication, SessionAuthentication)
+        permission_classes = (permissions.JWT_RESTRICTED_APPLICATION_OR_USER_ACCESS,)
+        required_scopes = ['required_scope']
+
+        def get(self, request, course_id=None):
+            return Response(data="Success")
+
+    def _create_user(self, is_staff=False):
+        return UserFactory(username='this_user', is_staff=is_staff)
+
+    def _create_request(self, username_in_url=None, auth_header=None):
+        url = '/'
+        if username_in_url:
+            url += '?username={}'.format(username_in_url)
+        extra = dict(HTTP_AUTHORIZATION=auth_header) if auth_header else dict()
+        return RequestFactory().get(url, **extra)
+
+    def _create_session(self, request, user):
+        request.user = user
+
+    def _create_jwt_header(self, user, is_restricted=False, scopes=None, filters=None):
+        token = generate_jwt(user, is_restricted=is_restricted, scopes=scopes, filters=filters)
+        return "JWT {}".format(token)
+
+    def _assert_log(self, mock_log, expected_log):
+        mock_log_method = getattr(mock_log, expected_log.method)
+        self.assertTrue(mock_log_method.called)
+        self.assertIn(expected_log.text, mock_log_method.call_args_list[0][0][0])
+        if expected_log.param is not None:
+            self.assertEqual(mock_log_method.call_args_list[0][0][1], expected_log.param)
+
+    def test_anonymous_fails(self):
+        request = self._create_request()
+        response = self.SomeClassView().dispatch(request)
+        self.assertEqual(response.status_code, 401)
+
+    def test_session_staff_succeeds(self):
+        user = self._create_user(is_staff=True)
+        request = self._create_request()
+        self._create_session(request, user)
+
+        response = self.SomeClassView().dispatch(request)
+        self.assertEqual(response.status_code, 200)
+
+    @patch('edx_rest_framework_extensions.permissions.log')
+    def test_session_user_not_in_url_fails(self, mock_log):
+        user = self._create_user()
+        request = self._create_request()
+        self._create_session(request, user)
+        
+        response = self.SomeClassView().dispatch(request)
+        self.assertEqual(response.status_code, 403)
+        self._assert_log(mock_log, self.IsUserInUrlLog)
+
+    def test_session_user_in_url_succeeds(self):
+        user = self._create_user()
+        request = self._create_request(username_in_url=user.username)
+        self._create_session(request, user)
+
+        response = self.SomeClassView().dispatch(request)
+        self.assertEqual(response.status_code, 200)
+
+    JwtTestCase = namedtuple('JwtTestCase', 'is_enforced, is_restricted, is_user_in_url, expected_response, expected_log')
+
+    @patch('edx_rest_framework_extensions.permissions.waffle.switch_is_active')
+    @patch('edx_rest_framework_extensions.permissions.log')
+    @ddt.data(
+        # **** Enforced ****
+        # unrestricted
+        JwtTestCase(is_enforced=True, is_restricted=False, is_user_in_url=True, expected_response=200, expected_log=JwtIsUnrestrictedLog),
+        JwtTestCase(is_enforced=True, is_restricted=False, is_user_in_url=False, expected_response=403, expected_log=IsUserInUrlLog),
+
+        # restricted
+        JwtTestCase(is_enforced=True, is_restricted=True, is_user_in_url=True, expected_response=403, expected_log=JwtHasScopeLog),
+        JwtTestCase(is_enforced=True, is_restricted=True, is_user_in_url=False, expected_response=403, expected_log=JwtHasScopeLog),
+
+        # **** Unenforced ****
+        # unrestricted
+        JwtTestCase(is_enforced=False, is_restricted=False, is_user_in_url=True, expected_response=200, expected_log=JwtIsUnrestrictedLog),
+        JwtTestCase(is_enforced=False, is_restricted=False, is_user_in_url=False, expected_response=403, expected_log=IsUserInUrlLog),
+
+        # restricted
+        JwtTestCase(is_enforced=False, is_restricted=True, is_user_in_url=True, expected_response=200, expected_log=JwtIsUnrestrictedLog),
+        JwtTestCase(is_enforced=False, is_restricted=True, is_user_in_url=False, expected_response=403, expected_log=IsUserInUrlLog),
+    )
+    @ddt.unpack
+    def test_jwt_cases(self, is_enforced, is_restricted, is_user_in_url, expected_response, expected_log, mock_log, waffle_mock):
+        waffle_mock.return_value = is_enforced
+        user = self._create_user()
+
+        auth_header = self._create_jwt_header(user, is_restricted=is_restricted)
+        request = self._create_request(
+            username_in_url=user.username if is_user_in_url else None,
+            auth_header=auth_header,
+        )
+
+        response = self.SomeClassView().dispatch(request)
+        self.assertEqual(response.status_code, expected_response)
+        self._assert_log(mock_log, expected_log)
+
+    JwtRestrictedTestCase = namedtuple('JwtRestrictedTestCase', 'scopes, filters, expected_response, expected_log')
+
+    @patch('edx_rest_framework_extensions.permissions.waffle.switch_is_active')
+    @patch('edx_rest_framework_extensions.permissions.log')
+    @ddt.data(
+        JwtRestrictedTestCase(scopes=['required_scope'], filters=['content_org:some_org'], expected_response=200, expected_log=JwtIsRestrictedLog),
+        JwtRestrictedTestCase(scopes=['required_scope', 'another_scope'], filters=['content_org:some_org'], expected_response=200, expected_log=JwtIsRestrictedLog),
+        JwtRestrictedTestCase(scopes=['required_scope'], filters=['content_org:some_org', 'some:other'], expected_response=200, expected_log=JwtIsRestrictedLog),
+
+        JwtRestrictedTestCase(scopes=['required_scope'], filters=['content_org:another_org'], expected_response=403, expected_log=JwtOrgFilterLog),
+        JwtRestrictedTestCase(scopes=['required_scope'], filters=[], expected_response=403, expected_log=JwtOrgFilterLog),
+
+        JwtRestrictedTestCase(scopes=[], filters=['content_org:some_org'], expected_response=403, expected_log=JwtHasScopeLog),
+        JwtRestrictedTestCase(scopes=['another_scope'], filters=['content_org:some_org'], expected_response=403, expected_log=JwtHasScopeLog),
+    )
+    @ddt.unpack
+    def test_jwt_enforced_restricted(self, scopes, filters, expected_response, expected_log, mock_log, waffle_mock):
+        waffle_mock.return_value = True
+        user = self._create_user()
+
+        auth_header = self._create_jwt_header(user, is_restricted=True, scopes=scopes, filters=filters)
+        request = self._create_request(auth_header=auth_header)
+
+        response = self.SomeClassView().dispatch(request, course_id='some_org/course/run')
+        self.assertEqual(response.status_code, expected_response)
+        self._assert_log(mock_log, expected_log)


### PR DESCRIPTION
In addition to minor improvements, this PR does the following:

- Adds a design pattern for centrally managing token versions and updates in jwt_decoder.py via `JwtTokenVersion` and `_upgrade_token`.
- Updates the `EnsureJWTAuthSettingsMiddleware` so it no longer adds `required_scopes` to Views.
Instead, the `JwtHasScope` Permission will fail if the view doesn't have `required_scopes`.
- Adds a `JwtHasUserFilterForRequestedUser` Permission to verify the `user:me` filter.
- Adds a `JWT_RESTRICTED_APPLICATION_OR_USER_ACCESS` Permission constant that encapsulates checking for Jwt related permissions for APIs that have course-related and user-related data.
