### PR TITLE
Avoids a common RemovedInDjango20Warning

### DIFF
--- a/edx_rest_framework_extensions/middleware.py
+++ b/edx_rest_framework_extensions/middleware.py
@@ -153,7 +153,7 @@ class RequestMetricsMiddleware(object):
                 auth_type = 'other-token-type'
         elif not hasattr(request, 'user') or not request.user:
             auth_type = 'no-user'
-        elif not request.user.is_authenticated():
+        elif not request.user.is_authenticated:
             auth_type = 'unauthenticated'
         else:
             auth_type = 'session-or-unknown'


### PR DESCRIPTION
This should clear up a lot of noise in the logs. (There are probably many more RemoveInDjango20Warnings to fix, elsewhere.)

@robrap 