### PR TITLE
ARCH-262: Minor clean-up of authn.

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '2.0.1'  # pragma: no cover
+__version__ = '2.0.2'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/middleware.py
+++ b/edx_rest_framework_extensions/auth/jwt/middleware.py
@@ -100,6 +100,13 @@ class JwtAuthCookieMiddleware(object):
             replaced by the cookie name, which may be set as a setting.  Defaults would
             be 'missing-edx-jwt-cookie-header-payload' or 'missing-edx-jwt-cookie-signature'.
 
+    This middleware must appear before any AuthenticationMiddleware.  For example::
+
+        MIDDLEWARE_CLASSES = (
+            'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
+            'django.contrib.auth.middleware.AuthenticationMiddleware',
+        )
+
     """
 
     def _get_missing_cookie_message_and_metric(self, cookie_name):

--- a/edx_rest_framework_extensions/middleware.py
+++ b/edx_rest_framework_extensions/middleware.py
@@ -3,8 +3,6 @@ Middleware to ensure best practices of DRF and other endpoints.
 """
 from edx_django_utils import monitoring
 
-from .permissions import NotJwtRestrictedApplication   # pylint: disable=unused-import
-
 
 class RequestMetricsMiddleware(object):
     """


### PR DESCRIPTION
1. Add a note for JwtAuthCookieMiddleware usage.
2. Remove unused import missed in earlier clean-up.

ARCH-262

FYI: It is not important to get this deployed, but just wanted to complete this update.