### PR TITLE
ARCH-283: Enhance exception message for jwt_decode_handler.

### DIFF
--- a/edx_rest_framework_extensions/auth/jwt/decoder.py
+++ b/edx_rest_framework_extensions/auth/jwt/decoder.py
@@ -93,7 +93,7 @@ def _set_token_defaults(token):
         )
         if jwt_version.major > supported_version.major:
             logger.info('Token decode failed due to unsupported JWT version number [%s]', str(jwt_version))
-            raise jwt.InvalidTokenError
+            raise jwt.InvalidTokenError('JWT version number [%s] is unsupported', str(jwt_version))
 
     def _get_and_set_version(token):
         """


### PR DESCRIPTION
Temporarily, ecommerce is delegating to this jwt_decode_handler, with
its own fallback to allow for multiple issuers. Logging suppression is
required until ecommerce is down to a single issuer and can use this
jwt_decode_handler directly.  Ecommerce needs to suppress logging
because the exceptions for BadSignature are invalid due to the fallback
decoder that can in fact properly decode the token.

Note: this should be reverted as part of ARCH-276.

ARCH-283

FYI: The version was already updated to 2.0.2 in a past PR but not yet released.