### PR TITLE
add request_user_id metric to new relic from middleware.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,7 @@ edX Django REST Framework Extensions  |Travis|_ |Codecov|_
 
 This library includes extensions of `Django REST Framework <http://www.django-rest-framework.org/>`_
 useful for edX applications.
+This library is also used for api extensions that do not use DRF.
 
 CSRF API
 --------

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '2.0.2'  # pragma: no cover
+__version__ = '2.0.3'  # pragma: no cover

--- a/edx_rest_framework_extensions/tests/test_middleware.py
+++ b/edx_rest_framework_extensions/tests/test_middleware.py
@@ -91,4 +91,11 @@ class TestRequestMetricsMiddleware(TestCase):
         self.request.user = UserFactory()
 
         self.middleware.process_response(self.request, None)
-        mock_set_custom_metric.assert_called_once_with('request_auth_type', 'session-or-unknown')
+        mock_set_custom_metric.assert_any_call('request_auth_type', 'session-or-unknown')
+
+    @patch('edx_django_utils.monitoring.set_custom_metric')
+    def test_request_user_id_metric(self, mock_set_custom_metric):
+        self.request.user = UserFactory()
+
+        self.middleware.process_response(self.request, None)
+        mock_set_custom_metric.assert_any_call('request_user_id', self.request.user.id)


### PR DESCRIPTION
see other PR for moving from edx-django-utils: https://github.com/edx/edx-django-utils/pull/18  

https://openedx.atlassian.net/browse/REVMI-35  

This is the approach @robrap recommended in the openedx slack architecture room.  
Also, I'm not sure how I would test this locally, so any tips would be appreciated!