### PR TITLE
ARCH-379: Remove version verification

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '2.0.3'  # pragma: no cover
+__version__ = '2.0.4'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/decoder.py
+++ b/edx_rest_framework_extensions/auth/jwt/decoder.py
@@ -15,10 +15,8 @@ logger = logging.getLogger(__name__)
 
 
 class JwtTokenVersion(object):
-    latest_supported = '1.1.0'
-
-    starting_version = '1.0.0'
-    added_version = '1.1.0'
+    # 1.1.0: The first version that was included directly in the token.
+    starting_version = '1.0.0'  # version used for tokens created before version was introduced.
 
 
 def jwt_decode_handler(token):
@@ -84,17 +82,8 @@ def decode_jwt_filters(token):
 def _set_token_defaults(token):
     """
     Returns an updated token that includes default values for
-    fields that were introduced since the token was created
-    by checking its version number.
+    certain fields that were introduced since the token was created.
     """
-    def _verify_version(jwt_version):
-        supported_version = Version(
-            settings.JWT_AUTH.get('JWT_SUPPORTED_VERSION', JwtTokenVersion.latest_supported)
-        )
-        if jwt_version.major > supported_version.major:
-            logger.info('Token decode failed due to unsupported JWT version number [%s]', str(jwt_version))
-            raise jwt.InvalidTokenError('JWT version number [%s] is unsupported', str(jwt_version))
-
     def _get_and_set_version(token):
         """
         Tokens didn't always contain a version number so we
@@ -126,8 +115,7 @@ def _set_token_defaults(token):
         if 'filters' not in token:
             token['filters'] = []
 
-    token_version = _get_and_set_version(token)
-    _verify_version(token_version)
+    _get_and_set_version(token)
     _set_is_restricted(token)
     _set_filters(token)
     return token

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_decoder.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_decoder.py
@@ -94,37 +94,6 @@ class JWTDecodeHandlerTests(TestCase):
 
             patched_log.exception.assert_any_call("Token verification failed.")
 
-    @override_settings(JWT_AUTH=exclude_from_jwt_auth_setting('JWT_SUPPORTED_VERSION'))
-    def test_supported_jwt_version_not_specified(self):
-        """
-        Verifies the JWT is decoded successfully when the JWT_SUPPORTED_VERSION setting is not specified.
-        """
-        token = generate_jwt_token(self.payload)
-        self.assertDictEqual(jwt_decode_handler(token), self.payload)
-
-    @ddt.data(None, '0.5.0', '1.0.0', '1.0.5', '1.5.0', '1.5.5')
-    def test_supported_jwt_version(self, jwt_version):
-        """
-        Verifies the JWT is decoded successfully with different supported versions in the token.
-        """
-        jwt_payload = generate_latest_version_payload(self.user, version=jwt_version)
-        token = generate_jwt_token(jwt_payload)
-        self.assertDictEqual(jwt_decode_handler(token), jwt_payload)
-
-    @override_settings(JWT_AUTH=update_jwt_auth_setting({'JWT_SUPPORTED_VERSION': '0.5.0'}))
-    def test_unsupported_jwt_version(self):
-        """
-        Verifies the function logs decode failures, and raises an
-        InvalidTokenError if the token version is not supported.
-        """
-        with mock.patch('edx_rest_framework_extensions.auth.jwt.decoder.logger') as patched_log:
-            with self.assertRaises(jwt.InvalidTokenError):
-                token = generate_jwt_token(self.payload)
-                jwt_decode_handler(token)
-
-            msg = "Token decode failed due to unsupported JWT version number [%s]"
-            patched_log.info.assert_any_call(msg, '1.1.0')
-
     def test_upgrade(self):
         """
         Verifies the JWT is upgraded when an old (starting) version is provided.

--- a/test_settings.py
+++ b/test_settings.py
@@ -47,8 +47,6 @@ JWT_AUTH = {
 
     'JWT_SECRET_KEY': 'test-key',
 
-    'JWT_SUPPORTED_VERSION': '1.0.0',
-
     'JWT_VERIFY_AUDIENCE': False,
 
     'JWT_VERIFY_EXPIRATION': True,


### PR DESCRIPTION
FYI: There are two ways to go here:
1. Leave this code and update the latest_supported version to 2.0.0, or
2. Drop the version checking.

I explain in the commit comment below why I chose #2.

IMPORTANT: I haven't completed the LMS side of this work.  At that point, it might make it more clear whether or not this was the right decision.  Reviewers should wait until that is ready.

-------------------------------------------

Separately, the LMS oauth_dispatch is being updated to be capable of
returning JWTs with different major versions when specifically
requested.

For the planned v1.x to v2.x JWT, the edx-drf-extensions _verify_version
call didn't actually help, and just forced an upgrade/deployment of
every service. Therefore, this check is being removed until/unless it
can be coded to solve a particular problem.

ARCH-379