### PR TITLE
ARCH-418: Remove jwt_refresh_cookie

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '2.4.3'  # pragma: no cover
+__version__ = '2.4.4'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/cookies.py
+++ b/edx_rest_framework_extensions/auth/jwt/cookies.py
@@ -19,10 +19,6 @@ def jwt_cookie_signature_name():
     return settings.JWT_AUTH.get('JWT_AUTH_COOKIE_SIGNATURE') or 'edx-jwt-cookie-signature'
 
 
-def jwt_refresh_cookie_name():
-    return settings.JWT_AUTH.get('JWT_AUTH_REFRESH_COOKIE') or 'edx-jwt-refresh-cookie'
-
-
 def get_decoded_jwt(request):
     """
     Grab jwt from jwt cookie in request if possible.

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_cookies.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_cookies.py
@@ -21,7 +21,6 @@ class TestJwtAuthCookies(TestCase):
         (cookies.jwt_cookie_name, 'JWT_AUTH_COOKIE', 'custom-jwt-cookie-name'),
         (cookies.jwt_cookie_header_payload_name, 'JWT_AUTH_COOKIE_HEADER_PAYLOAD', 'custom-jwt-header-payload-name'),
         (cookies.jwt_cookie_signature_name, 'JWT_AUTH_COOKIE_SIGNATURE', 'custom-jwt-signature-name'),
-        (cookies.jwt_refresh_cookie_name, 'JWT_AUTH_REFRESH_COOKIE', 'custom-jwt-refresh-name'),
     )
     @ddt.unpack
     def test_get_setting_value(self, jwt_cookie_func, setting_name, setting_value):
@@ -32,7 +31,6 @@ class TestJwtAuthCookies(TestCase):
         (cookies.jwt_cookie_name, 'edx-jwt-cookie'),
         (cookies.jwt_cookie_header_payload_name, 'edx-jwt-cookie-header-payload'),
         (cookies.jwt_cookie_signature_name, 'edx-jwt-cookie-signature'),
-        (cookies.jwt_refresh_cookie_name, 'edx-jwt-refresh-cookie'),
     )
     @ddt.unpack
     def test_get_default_value(self, jwt_cookie_func, expected_default_value):


### PR DESCRIPTION
The login_refresh endpoint in the LMS was updated to be based on the
user's session, rather than requiring an additional refresh cookie, so
removing any references to the unused refresh cookie and
JWT_AUTH_REFRESH_COOKIE setting.

https://openedx.atlassian.net/browse/ARCH-418