### PR TITLE
ARCH-603: add get_jwt_user_id call to JwtAuthCookieMiddleware

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '2.1.0'  # pragma: no cover
+__version__ = '2.2.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/utils.py
+++ b/edx_rest_framework_extensions/utils.py
@@ -1,4 +1,7 @@
 """ Utility functions. """
 
-# for compatibility with rest_framework_jwt
+from edx_django_utils.cache import RequestCache
+# Note: jwt_decode_handler import is for compatibility with rest_framework_jwt
 from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler  # pylint: disable=unused-import
+
+REQUEST_CACHE = RequestCache('edx_rest_framework_extensions')


### PR DESCRIPTION
The JwtAuthCookieMiddleware can now provide the user_id from the JWT,
when it exists, by caching it in the request.  Use
JwtAuthCookieMiddleware.get_jwt_user_id().

ARCH-603

Note: This is needed for ecommerce for calls from microfrontends to get access to the (lms) user_id for data analytics.