### PR TITLE
ENT-1783: Update cookies.get_decoded_jwt logic to also query jwt cookie from request.auth

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Clinton Blackburn <cblackburn@edx.org>
 Bill DeRusha <bill@edx.org>
 Jeremy Bowman <jbowman@edx.org>
 Robert Raposa <rraposa@edx.org>
+Saleem Latif <saleem_ee@hotmail.com>

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '2.2.0'  # pragma: no cover
+__version__ = '2.2.1'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/cookies.py
+++ b/edx_rest_framework_extensions/auth/jwt/cookies.py
@@ -29,7 +29,7 @@ def get_decoded_jwt(request):
     Returns a decoded jwt dict if it can be found.
     Returns None if the jwt is not found.
     """
-    jwt_cookie = request.COOKIES.get(jwt_cookie_name(), None)
+    jwt_cookie = request.COOKIES.get(jwt_cookie_name(), None) or getattr(request, 'auth', None)
 
     if not jwt_cookie:
         return None

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_cookies.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_cookies.py
@@ -46,6 +46,17 @@ class TestJwtAuthCookies(TestCase):
         self.assertEquals(expected_decoded_jwt, decoded_jwt)
 
     def test_get_decoded_jwt_when_no_cookie(self):
-        mock_request = mock.Mock(COOKIES={})
+        mock_request = mock.Mock(COOKIES={}, auth=None)
 
         self.assertIsNone(cookies.get_decoded_jwt(mock_request))
+
+    def test_get_decoded_jwt_from_auth(self):
+        user = UserFactory()
+        payload = generate_latest_version_payload(user)
+        jwt = generate_jwt_token(payload)
+        expected_decoded_jwt = jwt_decode_handler(jwt)
+
+        mock_request_with_cookie = mock.Mock(COOKIES={}, auth=jwt)
+
+        decoded_jwt = cookies.get_decoded_jwt(mock_request_with_cookie)
+        self.assertEquals(expected_decoded_jwt, decoded_jwt)


### PR DESCRIPTION
**Description:**
This PR updates the logic of `edx_rest_framework_extensions.auth.jwt.cookies.get_decoded_jwt` so that jwt cookie is queried in `request.auth` if not found in `request.COOKIES`. 