### PR TITLE
ENT-1783: Added a helper method to get jwt token from request.auth

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '2.2.2'  # pragma: no cover
+__version__ = '2.3.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from rest_framework import exceptions
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication, BaseJSONWebTokenAuthentication
 
+from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler
 from edx_rest_framework_extensions.settings import get_setting
 
 logger = logging.getLogger(__name__)
@@ -87,3 +88,16 @@ def is_jwt_authenticated(request):
             )
             return False
     return is_jwt_authenticated
+
+
+def get_decoded_jwt_from_auth(request):
+    """
+    Grab jwt from request.auth in request if possible.
+
+    Returns a decoded jwt dict if it can be found.
+    Returns None if the jwt is not found.
+    """
+    if not is_jwt_authenticated(request):
+        return None
+
+    return jwt_decode_handler(request.auth)


### PR DESCRIPTION
**Description:**
This PR adds a helper method in `edx_rest_framework_extensions/auth/jwt/authentication.py` to get decoded hwt token from `request.auth`