### PR TITLE
Fix call to is_jwt_authenticated when the request has no successful_authenticator attribute

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '2.3.0'  # pragma: no cover
+__version__ = '2.3.1'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -77,10 +77,13 @@ class JwtAuthentication(JSONWebTokenAuthentication):
 
 
 def is_jwt_authenticated(request):
-    is_jwt_authenticated = issubclass(
-        type(request.successful_authenticator),
-        BaseJSONWebTokenAuthentication,
-    )
+    is_jwt_authenticated = False
+    successful_authenticator = getattr(request, 'successful_authenticator', None)
+    if successful_authenticator:
+        is_jwt_authenticated = issubclass(
+            type(successful_authenticator),
+            BaseJSONWebTokenAuthentication
+        )
     if is_jwt_authenticated:
         if not getattr(request, 'auth', None):
             logger.error(


### PR DESCRIPTION
This should fix the errors we saw when the latest upgrade of this package went to prod.
```
exceptions:AttributeError: 'WSGIRequest' object has no attribute 'successful_authenticator'
Traceback (most recent call last):
File "/edx/app/edxapp/venvs/edxapp/bin/gunicorn", line 11, in <module>
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 74, in run
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/gunicorn/app/base.py", line 192, in run
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/gunicorn/app/base.py", line 72, in run
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/gunicorn/arbiter.py", line 185, in run
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/gunicorn/arbiter.py", line 484, in manage_workers
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/gunicorn/arbiter.py", line 549, in spawn_workers
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/gunicorn/arbiter.py", line 517, in spawn_worker
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/gunicorn/workers/base.py", line 128, in init_process
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/gunicorn/workers/sync.py", line 122, in run
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/gunicorn/workers/sync.py", line 66, in run_for_one
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/gunicorn/workers/sync.py", line 30, in accept
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/gunicorn/workers/sync.py", line 133, in handle
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/gunicorn/workers/sync.py", line 174, in handle_request
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/newrelic/api/wsgi_application.py", line 665, in _nr_wsgi_application_wrapper_
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/newrelic/api/wsgi_application.py", line 193, in __init__
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/newrelic/api/wsgi_application.py", line 555, in _nr_wsgi_application_wrapper_
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/wsgi.py", line 157, in __call__
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/newrelic/hooks/framework_django.py", line 423, in _nr_wrapper_BaseHandler_get_response_
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 124, in get_response
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/newrelic/hooks/framework_django.py", line 1203, in _wrapper
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 185, in inner
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/newrelic/hooks/framework_django.py", line 544, in wrapper
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rest_framework/viewsets.py", line 86, in view
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/newrelic/hooks/component_djangorestframework.py", line 46, in _nr_wrapper_APIView_dispatch_
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rest_framework/views.py", line 489, in dispatch
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/newrelic/hooks/component_djangorestframework.py", line 53, in _handle_exception_wrapper
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rest_framework/views.py", line 449, in handle_exception
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rest_framework/views.py", line 486, in dispatch
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edx_rbac/decorators.py", line 26, in wrapped_view
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/auth/models.py", line 277, in has_perm
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/auth/models.py", line 190, in _user_has_perm
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rules/permissions.py", line 32, in has_perm
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rules/permissions.py", line 24, in has_perm
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rules/rulesets.py", line 6, in test_rule
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rules/predicates.py", line 154, in test
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rules/predicates.py", line 213, in _apply
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rules/predicates.py", line 165, in OR
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rules/predicates.py", line 184, in _combine
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rules/predicates.py", line 213, in _apply
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/enterprise/rules.py", line 57, in has_implicit_access_to_catalog
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edx_rest_framework_extensions/auth/jwt/authentication.py", line 100, in get_decoded_jwt_from_auth
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edx_rest_framework_extensions/auth/jwt/authentication.py", line 81, in is_jwt_authenticated
```