### PR TITLE
Add MiddlewareMixin to all middleware classes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,6 @@ To make use of this API endpoint:
 #. Install edx-drf-extensions in your Django project.
 #. Add ``csrf.apps.CsrfAppConfig`` to ``INSTALLED_APPS``.
 #. Add ``'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware'`` to ``MIDDLEWARE``.
-   This class requires that you specify your middleware configuration with ``MIDDLEWARE`` and not
-   ``MIDDLEWARE_CLASSESS`` as in newer Django versions.
 
 License
 -------

--- a/edx_rest_framework_extensions/auth/jwt/middleware.py
+++ b/edx_rest_framework_extensions/auth/jwt/middleware.py
@@ -3,6 +3,7 @@ Middleware supporting JWT Authentication.
 """
 import logging
 
+from django.utils.deprecation import MiddlewareMixin
 from edx_django_utils import monitoring
 from rest_framework_jwt.authentication import BaseJSONWebTokenAuthentication
 
@@ -18,7 +19,7 @@ log = logging.getLogger(__name__)
 USE_JWT_COOKIE_HEADER = 'HTTP_USE_JWT_COOKIE'
 
 
-class EnsureJWTAuthSettingsMiddleware(object):
+class EnsureJWTAuthSettingsMiddleware(MiddlewareMixin):
     """
     Django middleware object that ensures the proper Permission classes
     are set on all endpoints that use JWTAuthentication.
@@ -80,7 +81,7 @@ class EnsureJWTAuthSettingsMiddleware(object):
             self._add_missing_jwt_permission_classes(view_class)
 
 
-class JwtAuthCookieMiddleware(object):
+class JwtAuthCookieMiddleware(MiddlewareMixin):
     """
     Reconstitutes JWT auth cookies for use by API views which use the JwtAuthentication
     authentication class.

--- a/edx_rest_framework_extensions/middleware.py
+++ b/edx_rest_framework_extensions/middleware.py
@@ -1,10 +1,10 @@
 """
 Middleware to ensure best practices of DRF and other endpoints.
 """
+from django.utils.deprecation import MiddlewareMixin
 from edx_django_utils import monitoring
 
-
-class RequestMetricsMiddleware(object):
+class RequestMetricsMiddleware(MiddlewareMixin):
     """
     Adds various request related metrics.
 


### PR DESCRIPTION
Django >=1.10 uses a slightly different middleware framework. Using the old framework results in RemovedInDjango20 warnings. Django provides MiddlewareMixin for classes that work as both old-style and new-style middlewares. Inheriting from it allows clients of this library to move to the new middleware framwork and silence the deprecation warnings.