### PR TITLE
ARCH-1051: enables this to work with jwt auth login required middleware

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '2.3.8'  # pragma: no cover
+__version__ = '2.4.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/middleware.py
+++ b/edx_rest_framework_extensions/middleware.py
@@ -4,6 +4,7 @@ Middleware to ensure best practices of DRF and other endpoints.
 from django.utils.deprecation import MiddlewareMixin
 from edx_django_utils import monitoring
 
+
 class RequestMetricsMiddleware(MiddlewareMixin):
     """
     Adds various request related metrics.

--- a/edx_rest_framework_extensions/permissions.py
+++ b/edx_rest_framework_extensions/permissions.py
@@ -144,6 +144,19 @@ class JwtHasUserFilterForRequestedUser(BasePermission):
         return None
 
 
+class LoginRedirectIfUnauthenticated(IsAuthenticated):
+    """
+    A DRF permission class that will login redirect unauthorized users.
+
+    It can be used to convert a plain Django view that was using @login_required
+    into a DRF APIView, which is useful to enable our DRF JwtAuthentication class.
+
+    Requires JwtRedirectToLoginIfUnauthenticatedMiddleware to work.
+
+    """
+    pass
+
+
 _NOT_JWT_RESTRICTED_PERMISSIONS = C(NotJwtRestrictedApplication) & (C(IsStaff) | IsUserInUrl)
 _JWT_RESTRICTED_PERMISSIONS = (
     C(JwtRestrictedApplication) &

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     -rtest_requirements.txt
 
 commands =
-    django-admin.py test edx_rest_framework_extensions --settings=test_settings --with-coverage --cover-package=edx_rest_framework_extensions
+    django-admin.py test {posargs:edx_rest_framework_extensions} --settings=test_settings --with-coverage --cover-package=edx_rest_framework_extensions
     coverage report
 
 [testenv:quality]


### PR DESCRIPTION
Middleware enables DRF JwtAuthentication authentication class for
endpoints using the new LoginRequired permission class.

Enables a non-standard use of DRF, because DRF only supports returning
a 401 for unauthorized users, but this middleware allows a DRF endpoint
to redirect to login.

This can be used to convert a plain Django view which was using
@login_required into a DRF APIView, which is useful to enable our DRF
JwtAuthentication authentication class.

NOTE: This includes a breaking change that is unlikely to affect anyone
unless they subclassed `JwtAuthCookieMiddleware`, which switched from
using `process_request` to `process_view` so it would not run before
this new middleware.

ARCH-1051

The ecommerce PR that makes use of this middleware can be found here:
https://github.com/edx/ecommerce/pull/2533

Note: `JwtAuthCookieMiddleware` already includes a metric for whether or not the cookies are available, so we shouldn't need an additional metric.