### PR TITLE
ARCH-1197: request.user set in JwtAuthCookieMiddleware

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '2.4.0'  # pragma: no cover
+__version__ = '2.4.1'  # pragma: no cover


### PR DESCRIPTION
JWT cookie authentication uses DRF, which does not set `request.user`
until the Middleware call: `process_response`.  This change sets the
`request.user` in process_view, which happens after all
`process_request` calls.

This is has been added to the existing `JwtAuthCookieMiddleware`.

ARCH-1197