### PR TITLE
ARCH-1210: Add toggle to determine whether to set request.user.

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '2.4.1'  # pragma: no cover
+__version__ = '2.4.2'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/middleware.py
+++ b/edx_rest_framework_extensions/auth/jwt/middleware.py
@@ -12,6 +12,7 @@ from edx_django_utils.cache import RequestCache
 from rest_framework.request import Request
 from rest_framework_jwt.authentication import BaseJSONWebTokenAuthentication
 
+from edx_rest_framework_extensions.config import ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE
 from edx_rest_framework_extensions.auth.jwt.cookies import (
     jwt_cookie_name,
     jwt_cookie_header_payload_name,
@@ -19,6 +20,7 @@ from edx_rest_framework_extensions.auth.jwt.cookies import (
 )
 from edx_rest_framework_extensions.auth.jwt.constants import JWT_DELIMITER
 from edx_rest_framework_extensions.permissions import LoginRedirectIfUnauthenticated, NotJwtRestrictedApplication
+from edx_rest_framework_extensions.settings import get_setting
 
 log = logging.getLogger(__name__)
 USE_JWT_COOKIE_HEADER = 'HTTP_USE_JWT_COOKIE'
@@ -203,7 +205,8 @@ class JwtAuthCookieMiddleware(MiddlewareMixin):
         header_payload_cookie = request.COOKIES.get(jwt_cookie_header_payload_name())
         signature_cookie = request.COOKIES.get(jwt_cookie_signature_name())
 
-        if use_jwt_cookie_requested:
+        is_set_request_user_for_jwt_cookie_enabled = get_setting(ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE)
+        if use_jwt_cookie_requested and is_set_request_user_for_jwt_cookie_enabled:
             # DRF does not set request.user until process_response. This makes it available in process_view.
             # For more info, see https://github.com/jpadilla/django-rest-framework-jwt/issues/45#issuecomment-74996698
             request.user = SimpleLazyObject(lambda: _get_user_from_jwt(request, view_func))

--- a/edx_rest_framework_extensions/config.py
+++ b/edx_rest_framework_extensions/config.py
@@ -2,6 +2,18 @@
 Application configuration constants and code.
 """
 
-NAMESPACE_SWITCH = 'oauth2'
-SWITCH_ENFORCE_JWT_SCOPES = 'enforce_jwt_scopes'
-NAMESPACED_SWITCH_ENFORCE_JWT_SCOPES = '{}.{}'.format(NAMESPACE_SWITCH, SWITCH_ENFORCE_JWT_SCOPES)
+OAUTH_TOGGLE_NAMESPACE = 'oauth2'
+SWITCH_ENFORCE_JWT_SCOPES = '{}.enforce_jwt_scopes'.format(OAUTH_TOGGLE_NAMESPACE)
+
+# .. toggle_name: EDX_DRF_EXTENSIONS[ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE]
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Toggle for setting request.user with jwt cookie authentication
+# .. toggle_category: experiments
+# .. toggle_use_cases: incremental_release
+# .. toggle_creation_date: 2019-10-15
+# .. toggle_expiration_date: 2019-12-31
+# .. toggle_warnings: This feature fixed ecommerce, but broke edx-platform. The toggle enables us to fix over time.
+# .. toggle_tickets: ARCH-1210, ARCH-1199, ARCH-1197
+# .. toggle_status: supported
+ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE = 'ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE'

--- a/edx_rest_framework_extensions/permissions.py
+++ b/edx_rest_framework_extensions/permissions.py
@@ -9,7 +9,7 @@ from edx_rest_framework_extensions.auth.jwt.authentication import is_jwt_authent
 from edx_rest_framework_extensions.auth.jwt.decoder import (
     decode_jwt_filters, decode_jwt_scopes, decode_jwt_is_restricted
 )
-from edx_rest_framework_extensions.config import NAMESPACED_SWITCH_ENFORCE_JWT_SCOPES
+from edx_rest_framework_extensions.config import SWITCH_ENFORCE_JWT_SCOPES
 
 log = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ class JwtRestrictedApplication(BasePermission):
 
     @classmethod
     def is_enforced_and_jwt_restricted_app(cls, request):
-        is_enforcement_enabled = waffle.switch_is_active(NAMESPACED_SWITCH_ENFORCE_JWT_SCOPES)
+        is_enforcement_enabled = waffle.switch_is_active(SWITCH_ENFORCE_JWT_SCOPES)
         ret_val = is_enforcement_enabled and is_jwt_authenticated(request) and decode_jwt_is_restricted(request.auth)
         log.debug(u"Permission JwtRestrictedApplication: returns %s.", ret_val)
         return ret_val

--- a/edx_rest_framework_extensions/settings.py
+++ b/edx_rest_framework_extensions/settings.py
@@ -15,6 +15,8 @@ import warnings
 from django.conf import settings
 from rest_framework_jwt.settings import api_settings
 
+from edx_rest_framework_extensions.config import ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE
+
 logger = logging.getLogger(__name__)
 
 
@@ -26,7 +28,8 @@ DEFAULT_SETTINGS = {
         'administrator': 'is_staff',
         'email': 'email',
     },
-    'JWT_PAYLOAD_MERGEABLE_USER_ATTRIBUTES': ()
+    'JWT_PAYLOAD_MERGEABLE_USER_ATTRIBUTES': (),
+    ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE: False,
 }
 
 


### PR DESCRIPTION
Although setting the `request.user` during `process_view` worked to
solve ARCH-1197 in ecommerce, it introduced an OOM bug in edx-platform.

This introduces a temporary toggle using a Django Setting so that the
fix can remain in ecommerce without affecting other IDAs like
edx-platform.

Once ARCH-1199 is complete and the issue is fixed, it is expected that
this toggle will be removed.

ARCH-1210

**UPDATE:** The second commit refactors from a Waffle Switch to a Django Setting so that we are not blocked by Devops, since we don't have access to Ecommerce Admin in Production.  It also better allows me to check that the solution sticks for ecommerce.