### PR TITLE
Add API docs tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,8 +64,7 @@ target/
 .idea/
 
 # A common place to put virtual envs
-.venv
-.venv3
+.venv*
 
 # Temp file used by `make upgrade`
 test.tmp

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ requirements: piptools ## install dev requirements into current env
 test: ## run unit tests in all supported environments using tox
 	tox
 
-CHECK_DIRS=csrf edx_rest_framework_extensions
+STRICT_CHECK_DIRS=csrf edx_api_doc_tools
+CHECK_DIRS=$(STRICT_CHECK_DIRS) edx_rest_framework_extensions
 
 style: ## check that code is PEP-8 compliant.
 	pycodestyle *.py $(CHECK_DIRS)
@@ -60,7 +61,7 @@ isort_check: ## check that imports are correctly sorted
 	isort *.py $(CHECK_DIRS) --recursive  --check-only --diff
 
 linting: ## check code quality with pylint
-	pylint *.py csrf
+	pylint *.py $(STRICT_CHECK_DIRS)
 	# Disable "C" (convention) messages in `edx_rest_framework_extensions`
 	# because there are so many violations (TODO: fix them).
 	pylint --disable=C edx_rest_framework_extensions

--- a/edx_api_doc_tools/__init__.py
+++ b/edx_api_doc_tools/__init__.py
@@ -1,0 +1,38 @@
+"""
+Public Python API for REST documentation.
+
+The functions are split into separate files for code organization,
+but they are imported into here so they can be imported
+directly from `edx_api_doc_tools`.
+"""
+from __future__ import absolute_import, unicode_literals
+
+# Expose OpenAPI module through the edx_api_doc_tools package
+# so that general users don't have to know about drf_yasg.
+from drf_yasg import openapi
+
+# When adding new functions to this API,
+# add them to the appropriate sub-module,
+# and then "expose" them by importing them here.
+# Use explicit imports (as opposed to wildcard imports)
+# so that we hide internal names and keep this module
+# a nice catalog of functions.
+from .conf_utils import (
+    ApiSchemaGenerator,
+    get_docs_cache_timeout,
+    get_docs_urls,
+    make_api_info,
+    make_docs_data_view,
+    make_docs_ui_view,
+    make_docs_urls,
+)
+from .data import (
+    FILE_PARAM,
+    PARAM_TYPES,
+    ParameterLocation,
+    parameter,
+    path_parameter,
+    query_parameter,
+    string_parameter,
+)
+from .view_utils import is_schema_request, schema, schema_for

--- a/edx_api_doc_tools/apps.py
+++ b/edx_api_doc_tools/apps.py
@@ -1,0 +1,20 @@
+"""
+App for documenting REST API views,
+generating API spec files from them,
+and then serving those API specs as a UI.
+
+Under the hood, this app uses drf-yasg
+("Yet Another Swagger Generator for DRF")
+to generate API spec. It then uses Swagger to serve that spec.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.apps import AppConfig
+
+
+class EdxApiDocToolsConfig(AppConfig):
+    """
+    Configuration for this app.
+    """
+    name = 'edx_api_doc_tools'
+    verbose_name = 'edX REST API Documentation Tools'

--- a/edx_api_doc_tools/conf_utils.py
+++ b/edx_api_doc_tools/conf_utils.py
@@ -1,0 +1,148 @@
+"""
+Functions for setting up API doc generation & viewing in a repository.
+
+External users: import these from __init__.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.conf import settings
+from django.conf.urls import url
+from django.views.generic.base import RedirectView
+from drf_yasg import openapi
+from drf_yasg.generators import OpenAPISchemaGenerator
+from drf_yasg.views import get_schema_view
+from rest_framework import permissions
+
+
+def make_docs_urls(api_info):
+    """
+    Convenience function for creating API doc views given an API info object.
+
+    Arguments:
+        api_info (openapi.Info)
+
+    Returns: list[RegexURLPattern]
+        A list of url patterns to the API docs.
+    """
+    return get_docs_urls(
+        docs_data_view=make_docs_data_view(api_info),
+        docs_ui_view=make_docs_ui_view(api_info),
+    )
+
+
+def make_api_info(
+        title="Open edX APIs",
+        version="v1",
+        email="oscm@edx.org",
+        description="APIs for access to Open edX information",
+):
+    """
+    Build an API info object.
+
+    Arguments:
+        * title (str)
+        * version (str)
+        * email (str)
+        * description (str)
+
+    Returns: openapi.Info
+    """
+    return openapi.Info(
+        title=title,
+        default_version=version,
+        contact=openapi.Contact(email=email),
+        description=description,
+    )
+
+
+def get_docs_urls(docs_data_view, docs_ui_view):
+    """
+    Get some reasonable URL patterns to browsable API docs and API docs data.
+
+    If these URL patterns don't work for your service,
+    feel free to construct your own.
+
+    Arguments:
+        docs_data_view (openapi.Info): JSON/YAML view for API docs data.
+        docs_ui_view (openapi.Info): Nice HTML view for API docs.
+
+    Returns: list[RegexURLPattern]
+        A list of url patterns to the API docs.
+    """
+    return [
+        url(
+            r'^swagger(?P<format>\.json|\.yaml)$',
+            docs_data_view,
+            name='apidocs-data',
+        ),
+        url(
+            r'^api-docs/$',
+            docs_ui_view,
+            name='apidocs-ui',
+        ),
+        url(
+            r'^swagger/$',
+            RedirectView.as_view(pattern_name='apidocs-ui', permanent=False),
+            name='apidocs-ui-swagger',
+        ),
+    ]
+
+
+def make_docs_data_view(api_info):
+    """
+    Build View for API documentation data (either JSON or YAML).
+
+    Arguments:
+        api_info (openapi.Info)
+
+    Returns: View
+    """
+    return get_schema_view(
+        api_info,
+        generator_class=ApiSchemaGenerator,
+        public=True,
+        permission_classes=(permissions.AllowAny,),
+    ).without_ui(cache_timeout=get_docs_cache_timeout())
+
+
+def make_docs_ui_view(api_info):
+    """
+    Build View for browsable API documentation.
+
+    Arguments:
+        api_info (openapi.Info)
+
+    Returns: View
+    """
+    return get_schema_view(
+        api_info,
+        generator_class=ApiSchemaGenerator,
+        public=True,
+        permission_classes=(permissions.AllowAny,),
+    ).with_ui('swagger', cache_timeout=get_docs_cache_timeout())
+
+
+class ApiSchemaGenerator(OpenAPISchemaGenerator):
+    """
+    A schema generator for /api/*
+
+    Only includes endpoints in the /api/* url tree, and sets the path prefix
+    appropriately.
+    """
+    def get_endpoints(self, request):
+        endpoints = super(ApiSchemaGenerator, self).get_endpoints(request)
+        subpoints = {p: v for p, v in endpoints.items() if p.startswith("/api/")}
+        return subpoints
+
+    def determine_path_prefix(self, paths):
+        return "/api/"
+
+
+def get_docs_cache_timeout():
+    """
+    Return OPENAPI_CACHE_TIMEOUT setting, or zero if it's not defined.
+    """
+    try:
+        return settings.OPENAPI_CACHE_TIMEOUT
+    except AttributeError:
+        return 0

--- a/edx_api_doc_tools/conf_utils.py
+++ b/edx_api_doc_tools/conf_utils.py
@@ -23,6 +23,13 @@ def make_docs_urls(api_info):
 
     Returns: list[RegexURLPattern]
         A list of url patterns to the API docs.
+
+    Example:
+        # File: urls.py
+        from edx_api_doc_tools import make_docs_urls, make_api_info
+        urlpatterns = [ ... ] # Your URL patterns.
+        api_info = make_api_info(title="Awesome API", version="v42")
+        urlpatterns += make_docs_urls(api_info)
     """
     return get_docs_urls(
         docs_data_view=make_docs_data_view(api_info),
@@ -68,6 +75,13 @@ def get_docs_urls(docs_data_view, docs_ui_view):
 
     Returns: list[RegexURLPattern]
         A list of url patterns to the API docs.
+
+    Example:
+        # File: urls.py
+        from edx_api_doc_tools import get_docs_urls
+        from .views import custom_doc_data_view, custom_doc_ui_view
+        urlpatterns = [ ... ] # Your URL patterns.
+        urlpatterns += get_docs_urls(custom_doc_data_view, custom_doc_ui_view)
     """
     return [
         url(
@@ -96,6 +110,11 @@ def make_docs_data_view(api_info):
         api_info (openapi.Info)
 
     Returns: View
+
+    Example:
+        from edx_api_doc_tools import make_api_info, make_docs_data_view
+        api_info = make_api_info(title="Awesome API", version="v42")
+        my_data_view = make_docs_data_view(api_info)
     """
     return get_schema_view(
         api_info,
@@ -113,6 +132,11 @@ def make_docs_ui_view(api_info):
         api_info (openapi.Info)
 
     Returns: View
+
+    Example:
+        from edx_api_doc_tools import make_api_info, make_docs_ui_view
+        api_info = make_api_info(title="Awesome API", version="v42")
+        my_ui_view = make_docs_ui_view(api_info)
     """
     return get_schema_view(
         api_info,

--- a/edx_api_doc_tools/data.py
+++ b/edx_api_doc_tools/data.py
@@ -1,0 +1,95 @@
+"""
+Data definitions for API schemas.
+
+Mostly, we just use the definitions in drf_yasg.openapi
+"""
+from __future__ import absolute_import, unicode_literals
+
+from drf_yasg import openapi
+
+
+# Python 3 doesn't have a builtin `file` type,
+# so we need a constant instead.
+FILE_PARAM = 'file'
+
+
+# A map from builtin Python types to the corresponding OpenAPI type string constant.
+# The built-in types can be passed to the `parameter` function  in place of the
+# OpenAPI strings for convenience.
+_PARAM_TYPE_MAP = {
+    object: openapi.TYPE_OBJECT,
+    str: openapi.TYPE_STRING,
+    float: openapi.TYPE_NUMBER,
+    int: openapi.TYPE_INTEGER,
+    bool: openapi.TYPE_BOOLEAN,
+    list: openapi.TYPE_ARRAY,
+    FILE_PARAM: openapi.TYPE_FILE,
+}
+
+
+PARAM_TYPES = frozenset(_PARAM_TYPE_MAP.keys())
+
+
+def path_parameter(name, param_type, description=None):
+    """
+    Convenient function for defining a parameter in the endpoint's path.
+
+    Type must still be specified.
+    """
+    return parameter(name, ParameterLocation.PATH, param_type, description=description)
+
+
+def query_parameter(name, param_type, description=None):
+    """
+    Convenient function for defining a parameter in the endpoint's querystring.
+
+    Type must still be specified.
+    """
+    return parameter(name, ParameterLocation.QUERY, param_type, description=description)
+
+
+def string_parameter(name, in_, description=None):
+    """
+    Convenient function for defining a string parameter.
+
+    Location must still be specified.
+    """
+    return parameter(name, in_, str, description=description)
+
+
+def parameter(name, in_, param_type, description=None):
+    """
+    Define typed parameters.
+
+    Arguments:
+        name (str)
+        in_ (ParameterLocation attribute)
+        param_type (type|str): a member of either `PARAM_TYPES`
+        description (str)
+
+    Returns: openapi.Parameter
+    """
+    try:
+        openapi_type = _PARAM_TYPE_MAP[param_type]
+    except KeyError:
+        raise ValueError(
+            'param_type must be a member of the set {}'.format(PARAM_TYPES)
+        )
+    return openapi.Parameter(
+        name,
+        in_,
+        type=openapi_type,
+        description=description,
+    )
+
+
+class ParameterLocation(object):
+    """
+    Location of API parameter in request.
+    """
+    BODY = openapi.IN_BODY
+    PATH = openapi.IN_PATH
+    QUERY = openapi.IN_QUERY
+    FORM = openapi.IN_FORM
+    HEADER = openapi.IN_HEADER
+    __ALL__ = {BODY, PATH, QUERY, FORM, HEADER}

--- a/edx_api_doc_tools/example/__init__.py
+++ b/edx_api_doc_tools/example/__init__.py
@@ -1,0 +1,5 @@
+"""
+This is an example Django app that uses the API doc tools.
+
+It serves a simple Create-Read-Update-Delete REST API for data about hedgehogs.
+"""

--- a/edx_api_doc_tools/example/data.py
+++ b/edx_api_doc_tools/example/data.py
@@ -1,0 +1,36 @@
+"""
+Static example data for the edX Hedgehog API.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from collections import namedtuple
+from uuid import UUID
+
+
+Hedgehog = namedtuple(
+    'Hedgehog',
+    ('uuid', 'key', 'name', 'weight_grams', 'favorite_food', 'is_college_graduate'),
+)
+
+
+def get_hedgehogs():
+    """
+    Get a list of Hedgehog objects that make up the "edX Hedgehog Database".
+    """
+    return [
+        Hedgehog(_uuid(0), 'spike', 'Spike Lee', 361, 'strawberries', False),
+        Hedgehog(_uuid(1), 'skip', 'Skipper Quillson', 410, 'crawlies', False),
+        Hedgehog(_uuid(2), 'hedgy', 'Hedgy von Hog', 440, 'critters', False),
+        Hedgehog(_uuid(3), 'pepper', 'Pepper Pokes', 380, 'critters', False),
+        Hedgehog(_uuid(4), 'hbert', 'Hedgebert the Hedge Fund Manager', 350, 'critters', True),
+    ]
+
+
+def _uuid(i):
+    """
+    Returns a UUID-4 with a predetermined format, for test repeatability.
+
+    Example:
+        ``_uuid(23) == UUID('11111111-2222-4444-8888-000000000023')``
+    """
+    return UUID('11111111-2222-4444-8888-{:012}'.format(i))

--- a/edx_api_doc_tools/example/serializers.py
+++ b/edx_api_doc_tools/example/serializers.py
@@ -1,0 +1,38 @@
+"""
+REST API serializers for reading and writing to the edX Hedgehog Database.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from rest_framework import serializers
+
+
+# pylint: disable=abstract-method
+
+
+class HedgehogSerializer(serializers.Serializer):
+    """
+    Serializer for a hedgehog.
+    """
+    uuid = serializers.UUIDField()
+    key = serializers.SlugField()
+    name = serializers.CharField()
+    weight_grams = serializers.IntegerField()
+    # TODO: How can we make `weight_ounces` be schema'd as a float instead of a string?
+    weight_ounces = serializers.SerializerMethodField()
+    fav_food = serializers.ChoiceField(
+        [
+            ('critters', 'Critters'),
+            ('crawlies', 'Crawly things'),
+            ('strawberries', 'Strawberries'),
+        ],
+        allow_blank=True,
+        source='favorite_food',
+    )
+    is_college_graduate = serializers.BooleanField(default=False)
+
+    def get_weight_ounces(self, obj):
+        """
+        Convert the weight of the hedgehog `obj` from an `int` number of grams
+        to a `float` number of ounces.
+        """
+        return obj.weight_grams * 28.3495

--- a/edx_api_doc_tools/example/test_example.py
+++ b/edx_api_doc_tools/example/test_example.py
@@ -1,0 +1,86 @@
+"""
+Make sure our example API works,
+so that we're not testing our doc tools on a broken API.
+"""
+import json
+
+from django.test import SimpleTestCase
+from django.test.utils import override_settings
+
+from . import urls as example_urls
+
+
+@override_settings(ROOT_URLCONF=example_urls.__name__)
+class HedgehogViewTest(SimpleTestCase):
+    """
+    Test the HedgehogViewSet.
+    """
+    new_hog = {
+        'uuid': '44444444-4444-4444-4444-444444444444',
+        'key': 'erin',
+        'name': "Erin Aceinae",
+        'weight_grams': 432,
+        'fav_food': "strawberries",
+        'is_college_graduate': True,
+    }
+    updated_hog = {
+        'name': "Cornelius Quillson",
+        'weight_grams': 465,
+    }
+    invalid_hog = {
+        'key': 'nope',
+        'name': 'Nopey McNopeface',
+        # (missing the other required fields)
+    }
+
+    def request(self, method, path, data=None):
+        """
+        Make a `method` request to `path` in the hedgehog API with (optional) `data`.
+        """
+        request_method = getattr(self.client, method.lower())
+        args = ['/api/hedgehog/v0/{}'.format(path)]
+        if data:
+            args.append(json.dumps(data))
+        return request_method(*args, content_type='application/json')
+
+    def test_list(self):
+        response = self.request('get', 'hogs/')
+        assert response.status_code == 200
+        assert len(response.data) == 5
+
+    def test_get(self):
+        response = self.request('get', 'hogs/pepper/')
+        assert response.status_code == 200
+        assert response.data['name'] == 'Pepper Pokes'
+
+    def test_post(self):
+        response = self.request('post', 'hogs/', self.new_hog)
+        assert response.status_code == 501
+
+    def test_post_400(self):
+        response = self.request('post', 'hogs/', self.invalid_hog)
+        assert response.status_code == 400
+
+    def test_put(self):
+        response = self.request('put', 'hogs/skip/', self.new_hog)
+        assert response.status_code == 501
+
+    def test_put_404(self):
+        response = self.request('put', 'hogs/erin/', self.new_hog)
+        assert response.status_code == 404
+
+    def test_patch(self):
+        response = self.request('patch', 'hogs/skip/', self.updated_hog)
+        assert response.status_code == 501
+
+    def test_patch_404(self):
+        response = self.request('patch', 'hogs/erin/', self.new_hog)
+        assert response.status_code == 404
+
+    def test_destroy(self):
+        response = self.request('delete', 'hogs/skip/')
+        assert response.status_code == 501
+
+    def test_destroy_404(self):
+        response = self.request('delete', 'hogs/erin/')
+        assert response.status_code == 404

--- a/edx_api_doc_tools/example/urls.py
+++ b/edx_api_doc_tools/example/urls.py
@@ -1,0 +1,25 @@
+"""
+REST API URLs for reading and writing to the edX Hedgehog Database.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from rest_framework.routers import SimpleRouter
+
+from .. import make_api_info, make_docs_urls
+from .views import HedgehogViewSet
+
+
+urlpatterns = []
+
+ROUTER = SimpleRouter()
+ROUTER.register(r'api/hedgehog/v0/hogs', HedgehogViewSet, basename='hedgehog')
+urlpatterns += ROUTER.urls
+
+urlpatterns += make_docs_urls(
+    make_api_info(
+        title="edX Hedgehog Service API",
+        version="v0",
+        email="hedgehog-support@example.com",
+        description="A REST API for interacting with the edX hedgehog service.",
+    ),
+)

--- a/edx_api_doc_tools/example/views.py
+++ b/edx_api_doc_tools/example/views.py
@@ -1,0 +1,103 @@
+"""
+REST API views for reading and writing to the edX Hedgehog Database.
+
+Documented using edx_api_doc_tools.
+
+TODO! finish documenting HedgehogViewSet.
+
+TODO: also give an example of documenting "traditional" (non-ViewSet) DRF views.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from rest_framework.exceptions import APIException, NotFound
+from rest_framework.viewsets import ModelViewSet
+
+from edx_api_doc_tools import path_parameter, query_parameter, schema_for
+
+from .data import get_hedgehogs
+from .serializers import HedgehogSerializer
+
+
+@schema_for(
+    'list',
+    """
+    Fetch the list of edX hedgehogs.
+
+    Hedgehogs can be filtered by minimum weight (grams or ounces),
+    their favorite food, whether they graduated college,
+    or any combination of those criterion.
+    """,
+    parameters=[
+        query_parameter('min-grams', int, "Filter on whether minimum weight (grams)."),
+        query_parameter('min-ounces', float, "Filter hogs by minimum weight (ounces)."),
+        query_parameter('fav-food', str, "Filter hogs by favorite food."),
+        query_parameter('graduated', bool, "Filter hogs by whether they graudated."),
+    ],
+)
+@schema_for(
+    'retrieve',
+    # TODO!: The below string becomes the operation's description instead
+    #        of its summary for some reason.
+    """
+    Fetch details for a _single_ hedgehog by key.
+    """,
+    parameters=[
+        path_parameter(
+            'hedgehog_key', str, "Key identifying the a hog. Lowercase, letters only."
+        ),
+    ],
+    responses={
+        404: 'hedgehog with given key not found',
+    },
+)
+class HedgehogViewSet(ModelViewSet):
+    """
+    A viewset for hedgehogs.
+    """
+    serializer_class = HedgehogSerializer
+    lookup_field = 'hedgehog_key'
+
+    def get_queryset(self):
+        return get_hedgehogs()
+
+    def get_object(self):
+        """
+        Fetch a specific hedgehog by their key.
+        """
+        hedgehog_key = self.kwargs[self.lookup_field]
+        try:
+            hedgehog = next(
+                hog for hog in self.get_queryset()
+                if hog.key == hedgehog_key
+            )
+        except StopIteration:
+            raise NotFound()
+        return hedgehog
+
+    def perform_create(self, serializer):
+        """
+        Unimplemented: create a Hedeghog; result of a POST.
+        """
+        raise EndpointNotImplemented()
+
+    def perform_update(self, serializer):
+        """
+        Unimplemented: create a Hedeghog; result of a PUT.
+        """
+        raise EndpointNotImplemented()
+
+    def perform_destroy(self, instance):
+        """
+        Unimplemented: create a Hedeghog; result of a DELETE.
+        """
+        raise EndpointNotImplemented()
+
+
+class EndpointNotImplemented(APIException):
+    """
+    Exception to show that the request to the example view was fine,
+    but we haven't implemented it.
+    """
+    status_code = 501
+    default_detail = 'This example endpoint is not implemented.'
+    default_code = 'not_implemented'

--- a/edx_api_doc_tools/internal_utils.py
+++ b/edx_api_doc_tools/internal_utils.py
@@ -1,0 +1,19 @@
+"""
+Utility functions internal to this package.
+"""
+import textwrap
+
+
+def dedent(text):
+    """
+    Dedent multi-line text nicely.
+
+    An initial empty line is ignored so that triple-quoted strings don't need
+    to start with a backslash.
+    """
+    if "\n" in text:
+        first, rest = text.split("\n", 1)
+        if not first.strip():
+            # First line is blank, discard it.
+            text = rest
+    return textwrap.dedent(text)

--- a/edx_api_doc_tools/tests/.gitignore
+++ b/edx_api_doc_tools/tests/.gitignore
@@ -1,0 +1,1 @@
+actual_schema.json

--- a/edx_api_doc_tools/tests/expected_schema.json
+++ b/edx_api_doc_tools/tests/expected_schema.json
@@ -1,0 +1,261 @@
+{
+    "info": {
+        "contact": {
+            "email": "hedgehog-support@example.com"
+        }, 
+        "description": "A REST API for interacting with the edX hedgehog service.", 
+        "version": "v0", 
+        "title": "edX Hedgehog Service API"
+    }, 
+    "paths": {
+        "/hedgehog/v0/hogs/": {
+            "post": {
+                "responses": {
+                    "201": {
+                        "description": "", 
+                        "schema": {
+                            "$ref": "#/definitions/Hedgehog"
+                        }
+                    }
+                }, 
+                "tags": [
+                    "hedgehog"
+                ], 
+                "description": "A viewset for hedgehogs.", 
+                "parameters": [
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/Hedgehog"
+                        }, 
+                        "required": true, 
+                        "name": "data", 
+                        "in": "body"
+                    }
+                ], 
+                "operationId": "hedgehog_v0_hogs_create"
+            }, 
+            "parameters": [], 
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "", 
+                        "schema": {
+                            "items": {
+                                "$ref": "#/definitions/Hedgehog"
+                            }, 
+                            "type": "array"
+                        }
+                    }
+                }, 
+                "parameters": [
+                    {
+                        "description": "Filter on whether minimum weight (grams).", 
+                        "type": "integer", 
+                        "name": "min-grams", 
+                        "in": "query"
+                    }, 
+                    {
+                        "description": "Filter hogs by minimum weight (ounces).", 
+                        "type": "number", 
+                        "name": "min-ounces", 
+                        "in": "query"
+                    }, 
+                    {
+                        "description": "Filter hogs by favorite food.", 
+                        "type": "string", 
+                        "name": "fav-food", 
+                        "in": "query"
+                    }, 
+                    {
+                        "description": "Filter hogs by whether they graudated.", 
+                        "type": "boolean", 
+                        "name": "graduated", 
+                        "in": "query"
+                    }
+                ], 
+                "tags": [
+                    "hedgehog"
+                ], 
+                "summary": "Fetch the list of edX hedgehogs.", 
+                "operationId": "hedgehog_v0_hogs_list", 
+                "description": "Hedgehogs can be filtered by minimum weight (grams or ounces),\ntheir favorite food, whether they graduated college,\nor any combination of those criterion."
+            }
+        }, 
+        "/hedgehog/v0/hogs/{hedgehog_key}/": {
+            "put": {
+                "responses": {
+                    "200": {
+                        "description": "", 
+                        "schema": {
+                            "$ref": "#/definitions/Hedgehog"
+                        }
+                    }
+                }, 
+                "tags": [
+                    "hedgehog"
+                ], 
+                "description": "A viewset for hedgehogs.", 
+                "parameters": [
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/Hedgehog"
+                        }, 
+                        "required": true, 
+                        "name": "data", 
+                        "in": "body"
+                    }
+                ], 
+                "operationId": "hedgehog_v0_hogs_update"
+            }, 
+            "delete": {
+                "responses": {
+                    "204": {
+                        "description": ""
+                    }
+                }, 
+                "tags": [
+                    "hedgehog"
+                ], 
+                "description": "A viewset for hedgehogs.", 
+                "parameters": [], 
+                "operationId": "hedgehog_v0_hogs_delete"
+            }, 
+            "patch": {
+                "responses": {
+                    "200": {
+                        "description": "", 
+                        "schema": {
+                            "$ref": "#/definitions/Hedgehog"
+                        }
+                    }
+                }, 
+                "tags": [
+                    "hedgehog"
+                ], 
+                "description": "A viewset for hedgehogs.", 
+                "parameters": [
+                    {
+                        "schema": {
+                            "$ref": "#/definitions/Hedgehog"
+                        }, 
+                        "required": true, 
+                        "name": "data", 
+                        "in": "body"
+                    }
+                ], 
+                "operationId": "hedgehog_v0_hogs_partial_update"
+            }, 
+            "parameters": [
+                {
+                    "required": true, 
+                    "type": "string", 
+                    "name": "hedgehog_key", 
+                    "in": "path"
+                }
+            ], 
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "", 
+                        "schema": {
+                            "$ref": "#/definitions/Hedgehog"
+                        }
+                    }, 
+                    "404": {
+                        "description": "hedgehog with given key not found"
+                    }
+                }, 
+                "tags": [
+                    "hedgehog"
+                ], 
+                "description": "Fetch details for a _single_ hedgehog by key.", 
+                "parameters": [
+                    {
+                        "description": "Key identifying the a hog. Lowercase, letters only.", 
+                        "required": true, 
+                        "type": "string", 
+                        "name": "hedgehog_key", 
+                        "in": "path"
+                    }
+                ], 
+                "operationId": "hedgehog_v0_hogs_read"
+            }
+        }
+    }, 
+    "schemes": [
+        "http"
+    ], 
+    "produces": [
+        "application/json"
+    ], 
+    "basePath": "/api", 
+    "securityDefinitions": {
+        "Basic": {
+            "type": "basic"
+        }
+    }, 
+    "host": "testserver", 
+    "definitions": {
+        "Hedgehog": {
+            "required": [
+                "uuid", 
+                "key", 
+                "name", 
+                "weight_grams", 
+                "fav_food"
+            ], 
+            "type": "object", 
+            "properties": {
+                "is_college_graduate": {
+                    "default": false, 
+                    "type": "boolean", 
+                    "title": "Is college graduate"
+                }, 
+                "uuid": {
+                    "format": "uuid", 
+                    "type": "string", 
+                    "title": "Uuid"
+                }, 
+                "weight_grams": {
+                    "type": "integer", 
+                    "title": "Weight grams"
+                }, 
+                "weight_ounces": {
+                    "readOnly": true, 
+                    "type": "string", 
+                    "title": "Weight ounces"
+                }, 
+                "key": {
+                    "pattern": "^[-a-zA-Z0-9_]+$", 
+                    "format": "slug", 
+                    "type": "string", 
+                    "minLength": 1, 
+                    "title": "Key"
+                }, 
+                "fav_food": {
+                    "enum": [
+                        "critters", 
+                        "crawlies", 
+                        "strawberries"
+                    ], 
+                    "type": "string", 
+                    "title": "Fav food"
+                }, 
+                "name": {
+                    "minLength": 1, 
+                    "type": "string", 
+                    "title": "Name"
+                }
+            }
+        }
+    }, 
+    "security": [
+        {
+            "Basic": []
+        }
+    ], 
+    "swagger": "2.0", 
+    "consumes": [
+        "application/json"
+    ]
+}

--- a/edx_api_doc_tools/tests/test_doc_tools.py
+++ b/edx_api_doc_tools/tests/test_doc_tools.py
@@ -54,7 +54,26 @@ class DocViewTests(SimpleTestCase):
         )
 
     def test_get_ui_view(self):
+        """
+        Test that the UI view returns a page with the expected title.
+
+        We can't assert anything about page content, because that is all loaded
+        via an AJAX call to /api-docs/?format=openapi
+        """
         response = self.client.get('/api-docs/')
         assert response.status_code == 200
-        assert 'edX Hedgehog Service API' in response.content.decode('utf-8')
-        # TODO!: make some more assertions about substrings.
+        content = response.content.decode('utf-8')
+        assert '<title>edX Hedgehog Service API</title>' in content
+
+    def test_ui_data_endpoint(self):
+        """
+        Test that the the endpoint that the UI calls via AJAX returns the same data
+        as the schema endpoint.
+        """
+        data_response = self.client.get('/swagger.json', )
+        ui_data_response = self.client.get('/api-docs/?format=openapi')
+        assert ui_data_response.status_code == data_response.status_code == 200
+        expected = data_response.json()
+        # Cannot use `.json()` because response has content type 'application/openapi+json'.
+        actual = json.loads(ui_data_response.content.decode('utf-8'))
+        assert actual == expected

--- a/edx_api_doc_tools/tests/test_doc_tools.py
+++ b/edx_api_doc_tools/tests/test_doc_tools.py
@@ -1,0 +1,60 @@
+"""
+Tests for API docs tooling.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import json
+from os.path import dirname, join
+
+from django.test import SimpleTestCase
+from django.test.utils import override_settings
+
+from ..example import urls as example_urls
+
+
+@override_settings(ROOT_URLCONF=example_urls.__name__)
+class DocViewTests(SimpleTestCase):
+    """
+    Test that the API docs generated from the example Hedgehog API look right.
+    """
+    base_path = dirname(__file__)
+    path_of_expected_schema = join(base_path, 'expected_schema.json')
+    path_of_actual_schema = join(base_path, 'actual_schema.json')
+
+    def test_get_data_view(self):
+        """
+        Test that the generated API schema equals the reference schema.
+
+        How this test works:
+        * Generate a Swagger schema by GETting /swagger.json, and then dumping it to
+          actual_schema.json.
+        * Load example_schema.json.
+        * Assert that actual_schema.json and example_schema.json are equivalent.
+
+        If you make a change to the doc tools or the example API that change the
+        generated schema, here's how to update this test:
+        * Run the test, which should fail with an AssertionError about the
+          generated schema.
+        * Copy the contents of actual_schema.json into https://editor.swagger.io
+        * Make sure the browsable API looks correct,
+          and make sure the contents of the schema file look sane.
+        * If everything looks right, copy actual_schema.json into expected_schema.json
+          and commit the change, making it the new reference schema.
+        """
+        response = self.client.get('/swagger.json')
+        assert response.status_code == 200
+        actual_schema = response.json()
+        with open(self.path_of_actual_schema, 'w') as f:
+            json.dump(actual_schema, f, indent=4)
+        with open(self.path_of_expected_schema, 'r') as schema_file:
+            expected_schema = json.load(schema_file)
+        assert actual_schema == expected_schema, (
+            "Generated schema (dumped to actual_schema.json) "
+            "did not match schema loaded from expected_schema.json."
+        )
+
+    def test_get_ui_view(self):
+        response = self.client.get('/api-docs/')
+        assert response.status_code == 200
+        assert 'edX Hedgehog Service API' in response.content.decode('utf-8')
+        # TODO!: make some more assertions about substrings.

--- a/edx_api_doc_tools/view_utils.py
+++ b/edx_api_doc_tools/view_utils.py
@@ -1,0 +1,124 @@
+"""
+Utilities for annotating API views with schema info as well as
+extracting schema info from them.
+
+External users: import these from __init__.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import six
+from django.utils.decorators import method_decorator
+from drf_yasg.utils import swagger_auto_schema
+
+from .internal_utils import dedent
+
+
+def schema_for(method_name, docstring, *schema_args, **schema_kwargs):
+    """
+    Decorate a class to specify a schema for one of its methods.
+
+    Useful when the method you are describing is not defined inside of your
+    class body, but is instead defined somewhere up in the DRF view hierarchy.
+    (For applying a schema directly to a method, use the `schema` decorator).
+
+    DRF method names include:
+        'list', 'retrieve', 'get',
+        'post', 'create',
+        'put', 'update',
+        'patch', 'partial_update',
+        'delete', and 'destroy'.
+
+    The docstring of the specified method is replaced with `docstring`.
+    """
+    def schema_for_inner(view_class):
+        """
+        Final view class decorator
+        """
+        decorated_class = method_decorator(
+            name=method_name,
+            decorator=schema(*schema_args, **schema_kwargs),
+        )(view_class)
+        view_func = six.get_unbound_function(getattr(decorated_class, method_name))
+        view_func.__doc__ = docstring
+        return decorated_class
+    return schema_for_inner
+
+
+def schema(parameters=None, responses=None):
+    """
+    Decorator for documenting an API endpoint.
+
+    The operation summary and description are taken from the function docstring. All
+    description fields should be in Markdown and will be automatically dedented.
+
+    Args:
+        parameters (list[openapi.Parameter]):
+            Optional list of parameters to the API endpoint.
+        responses (dict[int, object]):
+            Optional map from HTTP statuses to either:
+                * a serializer class corresponding to that status
+                * a string describing when that status occurs
+                * an openapi.Schema object
+                * `None`, which indicates "don't include this response".
+    """
+    for param in parameters or ():
+        param.description = dedent(param.description)
+
+    # TODO: Remove this line when we drop Python 2 support.
+    responses = _fix_responses_for_python_2(responses)
+
+    def schema_inner(view_func):
+        """
+        Final view method decorator
+        """
+        summary = None
+        description = None
+        if view_func.__doc__:
+            doc_lines = view_func.__doc__.strip().split("\n")
+            if doc_lines:
+                summary = doc_lines[0].strip()
+            if len(doc_lines) > 1:
+                description = dedent("\n".join(doc_lines[1:]))
+        return swagger_auto_schema(
+            manual_parameters=parameters,
+            responses=responses,
+            operation_summary=summary,
+            operation_description=description,
+        )(view_func)
+    return schema_inner
+
+
+def _fix_responses_for_python_2(responses):
+    """
+    This is a temporary hack, necessary because drf-yasg doesn't explicitly support Python 2.
+
+    Specifically, drf-yasg expects string response descriptions to be of type `str`,
+    which in Py2, doesn't work on unicode strings.
+
+    The offending line:
+    https://github.com/axnsan12/drf-yasg/blob/13311582ea67da80204176211319b0a715802568/src/drf_yasg/inspectors/view.py#L249
+
+    TODO: Remove this function when we drop Python 2 support.
+
+    Arguments:
+        responses: dict[int, object]
+
+    Returns: dict[int, object]
+    """
+    if six.PY3 or responses is None:
+        return responses
+    return {
+        http_status: (
+            value.encode('utf-8')
+            if isinstance(value, unicode)  # pylint: disable=undefined-variable
+            else value
+        )
+        for http_status, value in responses.iteritems()
+    }
+
+
+def is_schema_request(request):
+    """
+    Is this request serving an OpenAPI schema?
+    """
+    return request.query_params.get('format') == 'openapi'

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '2.4.6'  # pragma: no cover
+__version__ = '3.0.0'  # pragma: no cover

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,4 +3,4 @@
 # Grab base requirements from setup.py.
 # This is a hack, and generates a line in base.txt
 # that needs to be deleted by `make upgrade`.
--e .
+-e .[api-doc-generation]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,28 +4,69 @@
 #
 #    make upgrade
 #
+alabaster==0.7.12         # via sphinx
+attrs==19.3.0             # via jsonschema
+babel==2.7.0              # via sphinx
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
+configparser==4.0.2       # via importlib-metadata
+contextlib2==0.6.0.post1  # via importlib-metadata
+coreapi==2.3.3            # via drf-yasg
+coreschema==0.0.4         # via coreapi, drf-yasg
 django-waffle==0.18.0     # via edx-django-utils
-django==1.11.26           # via edx-django-utils, rest-condition
+django==1.11.26           # via drf-yasg, edx-django-utils, rest-condition
 djangorestframework-jwt==1.11.0
-djangorestframework==3.9.4  # via rest-condition
+djangorestframework==3.9.4  # via drf-yasg, rest-condition
+docutils==0.15.2          # via m2r, sphinx
+drf-yasg==1.17.0
 edx-django-utils==2.0.2
 edx-opaque-keys==2.0.1
+functools32==3.2.3.post2 ; python_version == "2.7"  # via jsonschema
 future==0.18.2            # via pyjwkest
 idna==2.8                 # via requests
+imagesize==1.1.0          # via sphinx
+importlib-metadata==1.1.0  # via jsonschema
+inflection==0.3.1         # via drf-yasg
+itypes==1.1.0             # via coreapi
+jinja2==2.10.3            # via coreschema, sphinx
+jsonschema==3.2.0         # via sphinxcontrib-openapi
+m2r==0.2.1                # via sphinxcontrib-openapi
+markupsafe==1.1.1         # via jinja2
+mistune==0.8.4            # via m2r
+more-itertools==5.0.0     # via zipp
 newrelic==5.4.0.132       # via edx-django-utils
+packaging==19.2           # via drf-yasg, sphinx
+pathlib2==2.3.5           # via importlib-metadata
 pbr==5.4.4                # via stevedore
 psutil==1.2.1             # via edx-django-utils
 pycryptodomex==3.9.4      # via pyjwkest
+pygments==2.5.2           # via sphinx
 pyjwkest==1.3.2
 pyjwt==1.7.1              # via djangorestframework-jwt
 pymongo==3.9.0            # via edx-opaque-keys
+pyparsing==2.4.5          # via packaging
+pyrsistent==0.15.6        # via jsonschema
 python-dateutil==2.8.1
-pytz==2019.3              # via django
-requests==2.22.0          # via pyjwkest
+pytz==2019.3              # via babel, django
+pyyaml==5.2               # via sphinxcontrib-openapi
+requests==2.22.0          # via coreapi, pyjwkest, sphinx
 rest-condition==1.0.3
+ruamel.ordereddict==0.4.14 ; python_version == "2.7"  # via ruamel.yaml
+ruamel.yaml.clib==0.2.0   # via ruamel.yaml
+ruamel.yaml==0.16.5       # via drf-yasg
+scandir==1.10.0           # via pathlib2
 semantic-version==2.8.3
-six==1.13.0               # via edx-opaque-keys, pyjwkest, python-dateutil, stevedore
+six==1.13.0               # via drf-yasg, edx-opaque-keys, jsonschema, more-itertools, packaging, pathlib2, pyjwkest, pyrsistent, python-dateutil, sphinx, sphinxcontrib-httpdomain, stevedore
+snowballstemmer==2.0.0    # via sphinx
+sphinx==1.8.5             # via sphinxcontrib-httpdomain
+sphinxcontrib-httpdomain==1.7.0  # via sphinxcontrib-openapi
+sphinxcontrib-openapi[markdown]==0.5.0
+sphinxcontrib-websupport==1.1.2  # via sphinx
 stevedore==1.31.0         # via edx-opaque-keys
+typing==3.7.4.1           # via sphinx
+uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.25.7           # via requests
+zipp==0.6.0               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,5 +8,8 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# This package is a backport from python 3 that can only be installed in python 2.7
+# These packages are backports from python 3 that can only be installed in python 2.7
+backports.functools-lru-cache ; python_version == "2.7"
+functools32 ; python_version == "2.7"
 futures ; python_version == "2.7"
+ruamel.ordereddict ; python_version == "2.7"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,13 +9,15 @@ astroid==1.6.6
 atomicwrites==1.3.0
 attrs==19.3.0
 babel==2.7.0
-backports.functools-lru-cache==1.6.1
+backports.functools-lru-cache==1.6.1 ; python_version == "2.7"
 certifi==2019.11.28
 chardet==3.0.4
 click-log==0.3.2
 click==7.0
 configparser==4.0.2
 contextlib2==0.6.0.post1
+coreapi==2.3.3
+coreschema==0.0.4
 coverage==4.5.4
 ddt==1.2.2
 django-waffle==0.18.0
@@ -23,6 +25,7 @@ django==1.11.26
 djangorestframework-jwt==1.11.0
 djangorestframework==3.9.4
 docutils==0.15.2
+drf-yasg==1.17.0
 edx-django-utils==2.0.2
 edx-lint==1.4.1
 edx-opaque-keys==2.0.1
@@ -30,18 +33,24 @@ enum34==1.1.6
 factory-boy==2.12.0
 faker==2.0.5
 funcsigs==1.0.2
+functools32==3.2.3.post2 ; python_version == "2.7"
 future==0.18.2
 futures==3.1.1 ; python_version == "2.7"
 httpretty==0.9.7
 idna==2.8
 imagesize==1.1.0
 importlib-metadata==1.1.0
+inflection==0.3.1
 ipaddress==1.0.23
 isort==4.3.21
+itypes==1.1.0
 jinja2==2.10.3
+jsonschema==3.2.0
 lazy-object-proxy==1.4.3
+m2r==0.2.1
 markupsafe==1.1.1
 mccabe==0.6.1
+mistune==0.8.4
 mock==1.3.0
 more-itertools==5.0.0
 newrelic==5.4.0.132
@@ -62,13 +71,18 @@ pylint-plugin-utils==0.6
 pylint==1.9.5
 pymongo==3.9.0
 pyparsing==2.4.5
+pyrsistent==0.15.6
 pytest-cov==2.8.1
 pytest-django==3.7.0
 pytest==4.6.6
 python-dateutil==2.8.1
 pytz==2019.3
+pyyaml==5.2
 requests==2.22.0
 rest-condition==1.0.3
+ruamel.ordereddict==0.4.14 ; python_version == "2.7"
+ruamel.yaml.clib==0.2.0
+ruamel.yaml==0.16.5
 scandir==1.10.0
 semantic-version==2.8.3
 singledispatch==3.4.0.3
@@ -76,11 +90,14 @@ six==1.13.0
 snowballstemmer==2.0.0
 sphinx-rtd-theme==0.4.3
 sphinx==1.8.5
+sphinxcontrib-httpdomain==1.7.0
+sphinxcontrib-openapi[markdown]==0.5.0
 sphinxcontrib-websupport==1.1.2
 stevedore==1.31.0
 text-unidecode==1.3
 tox==2.9.1
 typing==3.7.4.1
+uritemplate==3.0.0
 urllib3==1.25.7
 virtualenv==16.7.8
 wcwidth==0.1.7

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -9,10 +9,8 @@ babel==2.7.0              # via sphinx
 docutils==0.15.2          # via sphinx
 imagesize==1.1.0          # via sphinx
 jinja2==2.10.3            # via sphinx
-markupsafe==1.1.1         # via jinja2
 packaging==19.2           # via sphinx
 pygments==2.5.2           # via sphinx
-pytz==2019.3              # via babel
 requests==2.22.0          # via sphinx
 six==1.13.0               # via sphinx
 snowballstemmer==2.0.0    # via sphinx

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,21 +4,27 @@
 #
 #    make upgrade
 #
+alabaster==0.7.12
 astroid==1.6.6            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
-attrs==19.3.0             # via pytest
-backports.functools-lru-cache==1.6.1  # via astroid, isort, pylint
+attrs==19.3.0
+babel==2.7.0
+backports.functools-lru-cache==1.6.1 ; python_version == "2.7"  # via astroid, isort, pylint
 certifi==2019.11.28
 chardet==3.0.4
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint
 configparser==4.0.2
 contextlib2==0.6.0.post1
+coreapi==2.3.3
+coreschema==0.0.4
 coverage==4.5.4
 ddt==1.2.2
 django-waffle==0.18.0
 djangorestframework-jwt==1.11.0
 djangorestframework==3.9.4
+docutils==0.15.2
+drf-yasg==1.17.0
 edx-django-utils==2.0.2
 edx-lint==1.4.1
 edx-opaque-keys==2.0.1
@@ -26,19 +32,28 @@ enum34==1.1.6             # via astroid
 factory-boy==2.12.0
 faker==2.0.5              # via factory-boy
 funcsigs==1.0.2           # via mock, pytest
+functools32==3.2.3.post2 ; python_version == "2.7"
 future==0.18.2
 futures==3.1.1 ; python_version == "2.7"
 httpretty==0.9.7
 idna==2.8
+imagesize==1.1.0
 importlib-metadata==1.1.0
+inflection==0.3.1
 ipaddress==1.0.23         # via faker
 isort==4.3.21
+itypes==1.1.0
+jinja2==2.10.3
+jsonschema==3.2.0
 lazy-object-proxy==1.4.3  # via astroid
+m2r==0.2.1
+markupsafe==1.1.1
 mccabe==0.6.1             # via pylint
+mistune==0.8.4
 mock==1.3.0
 more-itertools==5.0.0
 newrelic==5.4.0.132
-packaging==19.2           # via pytest
+packaging==19.2
 pathlib2==2.3.5
 pbr==5.4.4
 pluggy==0.13.1
@@ -46,6 +61,7 @@ psutil==1.2.1
 py==1.8.0
 pycodestyle==2.5.0
 pycryptodomex==3.9.4
+pygments==2.5.2
 pyjwkest==1.3.2
 pyjwt==1.7.1
 pylint-celery==0.3        # via edx-lint
@@ -53,23 +69,38 @@ pylint-django==0.11.1     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==1.9.5             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.9.0
-pyparsing==2.4.5          # via packaging
+pyparsing==2.4.5
+pyrsistent==0.15.6
 pytest-cov==2.8.1
 pytest-django==3.7.0
 pytest==4.6.6             # via pytest-cov, pytest-django
 python-dateutil==2.8.1
 pytz==2019.3
+pyyaml==5.2
 requests==2.22.0
 rest-condition==1.0.3
+ruamel.ordereddict==0.4.14 ; python_version == "2.7"
+ruamel.yaml.clib==0.2.0
+ruamel.yaml==0.16.5
 scandir==1.10.0
 semantic-version==2.8.3
 singledispatch==3.4.0.3   # via astroid, pylint
 six==1.13.0
+snowballstemmer==2.0.0
+sphinx==1.8.5
+sphinxcontrib-httpdomain==1.7.0
+sphinxcontrib-openapi[markdown]==0.5.0
+sphinxcontrib-websupport==1.1.2
 stevedore==1.31.0
 text-unidecode==1.3       # via faker
 tox==2.9.1
+typing==3.7.4.1
+uritemplate==3.0.0
 urllib3==1.25.7
 virtualenv==16.7.8
 wcwidth==0.1.7            # via pytest
 wrapt==1.11.2             # via astroid
 zipp==0.6.0
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,5 +17,5 @@ skip=
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = test_settings
-addopts = --cov csrf --cov edx_rest_framework_extensions --cov-report term-missing --cov-report html
+addopts = --cov csrf --cov edx_api_doc_tools --cov edx_rest_framework_extensions --cov-report term-missing --cov-report html
 norecursedirs = .*  tests.py docs requirements

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'djangorestframework',
         'djangorestframework-jwt>=1.7.2,<2.0.0',
         'django-waffle',
+        'drf-yasg',
         'psutil==1.2.1',  # dependency of edx-django-utils
         'edx-django-utils',
         'edx-opaque-keys',
@@ -49,5 +50,8 @@ setup(
         'requests>=2.7.0,<3.0.0',
         'rest-condition>=1.0.3,<2.0',
         'six',
-    ]
+    ],
+    extras_require={
+        "api-doc-generation": ["sphinxcontrib-openapi[markdown]"],
+    },
 )

--- a/test_settings.py
+++ b/test_settings.py
@@ -13,6 +13,8 @@ INSTALLED_APPS = (
     'csrf.apps.CsrfAppConfig',
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'drf_yasg',
+    'edx_api_doc_tools.apps.EdxApiDocToolsConfig',
     'edx_rest_framework_extensions',
     'waffle',
 )
@@ -27,6 +29,14 @@ DATABASES = {
         'PORT': '',
     }
 }
+
+TEMPLATES = [
+    {
+        'NAME': 'django',
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+    }
+]
 
 EDX_DRF_EXTENSIONS = {}
 


### PR DESCRIPTION
@nedbat @regisb -- Here's my stab at pulling the API doc tools out of `edx-platform` and into a shared repository. I settled on `edx-drf-extensions` because it's our canonical "REST API tooling" library and is already installed into most edX IDAs.

This PR creates a new folder called `edx_api_doc_tools` that exposes a toolkit of utilities through its `__init__.py`. It also has a silly "edX Hedgehog API" under `edx_api_doc_tools/example` that demonstrates how to use the doc tools. Finally, `edx_api_doc_tools/tests` does some baseline testing by looking at the JSON generated by from the example API.

There are a few `TODO`s scattered throughout this PR (hence its DRAFT status), but I wanted to solicit feedback early in case there are any major changes I need to make.

I haven't included Sphinx doc generation in this PR; I'm thinking that it could merge separately, while applying this PR's changes to `edx-platform` could be done in parallel.

Lastly, @regis and @nedbat , I plan on giving you both co-authorship on this final commit(s), as you wrote much of the original code; let me know if you have any qualms with that :)