### PR TITLE
ARCH-1269: remove jwt authentication from csrf endpoint 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,16 +10,14 @@ edX Django REST Framework Extensions  |Travis|_ |Codecov|_
 .. |Codecov| image:: http://codecov.io/github/edx/edx-drf-extensions/coverage.svg?branch=master
 .. _Codecov: http://codecov.io/github/edx/edx-drf-extensions?branch=master
 
-This library includes extensions of `Django REST Framework <http://www.django-rest-framework.org/>`_
-useful for edX applications.
-This library is also used for api extensions that do not use DRF.
+This library includes various cross-cutting concerns related to APIs. API functionality added to this library must be required for multiple Open edX applications or multiple repositories.
+
+Some of these concerns include extensions of `Django REST Framework <http://www.django-rest-framework.org/>`_ (DRF), which is how the repository initially got its name.
 
 CSRF API
 --------
 
-This library also includes a ``csrf`` app containing an API endpoint for retrieving CSRF tokens from
-the Django service in which it is installed. This is useful for frontend apps attempting to make POST,
-PUT, and DELETE requests to a Django service with Django's CSRF middleware enabled.
+One feature of this library is a ``csrf`` app containing an API endpoint for retrieving CSRF tokens from the Django service in which it is installed. This is useful for frontend apps attempting to make POST, PUT, and DELETE requests to a Django service with Django's CSRF middleware enabled.
 
 To make use of this API endpoint:
 
@@ -41,8 +39,7 @@ Contributions are very welcome.
 
 Please read `How To Contribute <https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst>`_ for details.
 
-Even though they were written with ``edx-platform`` in mind, the guidelines
-should be followed for Open edX code in general.
+Even though they were written with ``edx-platform`` in mind, the guidelines should be followed for Open edX code in general.
 
 Reporting Security Issues
 -------------------------

--- a/csrf/api/v1/views.py
+++ b/csrf/api/v1/views.py
@@ -3,11 +3,8 @@ API for CSRF application.
 """
 
 from django.middleware.csrf import get_token
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 
 
 class CsrfTokenView(APIView):
@@ -25,9 +22,6 @@ class CsrfTokenView(APIView):
             >>>     "csrfToken": "abcdefg1234567"
             >>> }
     """
-
-    authentication_classes = (JwtAuthentication,)
-    permission_classes = (IsAuthenticated,)
 
     def get(self, request):
         """

--- a/csrf/tests/test_api.py
+++ b/csrf/tests/test_api.py
@@ -4,9 +4,6 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from edx_rest_framework_extensions.auth.jwt.tests.utils import generate_jwt
-from edx_rest_framework_extensions.tests.factories import UserFactory
-
 
 class CsrfTokenTests(APITestCase):
     """ Tests for the CSRF token endpoint. """
@@ -16,9 +13,7 @@ class CsrfTokenTests(APITestCase):
         Ensure we can get a CSRF token.
         """
         url = reverse('csrf_token')
-        user = UserFactory()
-        jwt = generate_jwt(user)
-        self.client.credentials(HTTP_AUTHORIZATION='JWT {}'.format(jwt))  # pylint: disable=no-member
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('csrfToken', response.data)
+        self.assertIsNotNone(response.data['csrfToken'])

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '2.4.2'  # pragma: no cover
+__version__ = '2.4.3'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/constants.py
+++ b/edx_rest_framework_extensions/auth/jwt/constants.py
@@ -3,3 +3,4 @@ JWT Authentication constants.
 """
 
 JWT_DELIMITER = '.'
+USE_JWT_COOKIE_HEADER = 'HTTP_USE_JWT_COOKIE'

--- a/edx_rest_framework_extensions/auth/jwt/middleware.py
+++ b/edx_rest_framework_extensions/auth/jwt/middleware.py
@@ -12,7 +12,10 @@ from edx_django_utils.cache import RequestCache
 from rest_framework.request import Request
 from rest_framework_jwt.authentication import BaseJSONWebTokenAuthentication
 
-from edx_rest_framework_extensions.auth.jwt.constants import JWT_DELIMITER
+from edx_rest_framework_extensions.auth.jwt.constants import (
+    JWT_DELIMITER,
+    USE_JWT_COOKIE_HEADER,
+)
 from edx_rest_framework_extensions.auth.jwt.cookies import (
     jwt_cookie_header_payload_name,
     jwt_cookie_name,
@@ -27,7 +30,6 @@ from edx_rest_framework_extensions.settings import get_setting
 
 
 log = logging.getLogger(__name__)
-USE_JWT_COOKIE_HEADER = 'HTTP_USE_JWT_COOKIE'
 
 
 class EnsureJWTAuthSettingsMiddleware(MiddlewareMixin):

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_middleware.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_middleware.py
@@ -19,13 +19,13 @@ from rest_framework.views import APIView
 from rest_framework.viewsets import ViewSet
 from rest_framework_jwt.authentication import BaseJSONWebTokenAuthentication
 
+from edx_rest_framework_extensions.auth.jwt.constants import USE_JWT_COOKIE_HEADER
 from edx_rest_framework_extensions.auth.jwt.cookies import (
     jwt_cookie_header_payload_name,
     jwt_cookie_name,
     jwt_cookie_signature_name,
 )
 from edx_rest_framework_extensions.auth.jwt.middleware import (
-    USE_JWT_COOKIE_HEADER,
     EnsureJWTAuthSettingsMiddleware,
     JwtAuthCookieMiddleware,
     JwtRedirectToLoginIfUnauthenticatedMiddleware,

--- a/edx_rest_framework_extensions/config.py
+++ b/edx_rest_framework_extensions/config.py
@@ -9,7 +9,7 @@ SWITCH_ENFORCE_JWT_SCOPES = '{}.enforce_jwt_scopes'.format(OAUTH_TOGGLE_NAMESPAC
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False
 # .. toggle_description: Toggle for setting request.user with jwt cookie authentication
-# .. toggle_category: experiments
+# .. toggle_category: micro-frontend
 # .. toggle_use_cases: incremental_release
 # .. toggle_creation_date: 2019-10-15
 # .. toggle_expiration_date: 2019-12-31
@@ -17,3 +17,16 @@ SWITCH_ENFORCE_JWT_SCOPES = '{}.enforce_jwt_scopes'.format(OAUTH_TOGGLE_NAMESPAC
 # .. toggle_tickets: ARCH-1210, ARCH-1199, ARCH-1197
 # .. toggle_status: supported
 ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE = 'ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE'
+
+# .. toggle_name: EDX_DRF_EXTENSIONS[ENABLE_ANONYMOUS_ACCESS_ROLLOUT]
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Toggle for enabling some functionality related to anonymous access
+# .. toggle_category: micro-frontend
+# .. toggle_use_cases: incremental_release
+# .. toggle_creation_date: 2019-11-06
+# .. toggle_expiration_date: 2019-12-31
+# .. toggle_warnings: Requires coordination with MFE updates of frontend-auth refactor.
+# .. toggle_tickets: ARCH-1229
+# .. toggle_status: supported
+ENABLE_ANONYMOUS_ACCESS_ROLLOUT = 'ENABLE_ANONYMOUS_ACCESS_ROLLOUT'

--- a/edx_rest_framework_extensions/settings.py
+++ b/edx_rest_framework_extensions/settings.py
@@ -15,7 +15,10 @@ import warnings
 from django.conf import settings
 from rest_framework_jwt.settings import api_settings
 
-from edx_rest_framework_extensions.config import ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE
+from edx_rest_framework_extensions.config import (
+    ENABLE_ANONYMOUS_ACCESS_ROLLOUT,
+    ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -31,6 +34,7 @@ DEFAULT_SETTINGS = {
     },
     'JWT_PAYLOAD_MERGEABLE_USER_ATTRIBUTES': (),
     ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE: False,
+    ENABLE_ANONYMOUS_ACCESS_ROLLOUT: False,
 }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,14 +11,14 @@ deps =
     -rtest_requirements.txt
 
 commands =
-    django-admin.py test {posargs:edx_rest_framework_extensions} --settings=test_settings --with-coverage --cover-package=edx_rest_framework_extensions
+    django-admin.py test {posargs:csrf edx_rest_framework_extensions} --settings=test_settings --with-coverage --cover-package=csrf,edx_rest_framework_extensions
     coverage report
 
 [testenv:quality]
 commands =
     pycodestyle
-    isort --recursive edx_rest_framework_extensions csrf --check-only --diff
-    pylint --disable=R,C --rcfile=pylintrc edx_rest_framework_extensions csrf
+    isort --recursive csrf edx_rest_framework_extensions --check-only --diff
+    pylint --disable=R,C --rcfile=pylintrc csrf edx_rest_framework_extensions
 
 [testenv:docs]
 changedir=docs


### PR DESCRIPTION
**remove jwt authentication from csrf endpoint**

The main purpose of this commit is to remove the IsAuthenticated
permission from the /csrf/api/v1/token endpoint. The permission was
never needed, and doesn't allow the endpoint to be used to retrieve a
csrf token for use with an anonymous POST.

A temporary Django Setting was added to help with the roll-out:
- EDX_DRF_EXTENSIONS[ENABLE_ANONYMOUS_ACCESS_ROLLOUT]
This setting will help manage the rollout of CSRF protection.

Other minor fixes included:
- Updated README to clarify the purpose of the repo.
- Added testing of the existing csrf app to tox.

ARCH-1269