### PR TITLE
ARCH-1269: minor fixes to recent releases

### DIFF
--- a/csrf/api/v1/views.py
+++ b/csrf/api/v1/views.py
@@ -3,6 +3,7 @@ API for CSRF application.
 """
 
 from django.middleware.csrf import get_token
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -22,6 +23,8 @@ class CsrfTokenView(APIView):
             >>>     "csrfToken": "abcdefg1234567"
             >>> }
     """
+    # AllowAny keeps possible default of DjangoModelPermissions from being used.
+    permission_classes = (AllowAny,)
 
     def get(self, request):
         """

--- a/csrf/tests/test_api.py
+++ b/csrf/tests/test_api.py
@@ -1,5 +1,6 @@
 """ Tests for the CSRF API """
 
+from django.test.utils import override_settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -8,9 +9,15 @@ from rest_framework.test import APITestCase
 class CsrfTokenTests(APITestCase):
     """ Tests for the CSRF token endpoint. """
 
+    @override_settings(REST_FRAMEWORK={
+        'DEFAULT_PERMISSION_CLASSES': (
+            # Ensure this default permission does not interfere with the CSRF endpoint.
+            'rest_framework.permissions.DjangoModelPermissions',
+        ),
+    })
     def test_get_token(self):
         """
-        Ensure we can get a CSRF token.
+        Ensure we can get a CSRF token for an anonymous user.
         """
         url = reverse('csrf_token')
         response = self.client.get(url, format='json')

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '2.4.4'  # pragma: no cover
+__version__ = '2.4.5'  # pragma: no cover

--- a/edx_rest_framework_extensions/config.py
+++ b/edx_rest_framework_extensions/config.py
@@ -2,8 +2,20 @@
 Application configuration constants and code.
 """
 
-OAUTH_TOGGLE_NAMESPACE = 'oauth2'
-SWITCH_ENFORCE_JWT_SCOPES = '{}.enforce_jwt_scopes'.format(OAUTH_TOGGLE_NAMESPACE)
+# .. toggle_name: oauth2.enforce_jwt_scopes
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: Enforces JWT Scopes for an IDA. See https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0006-enforce-scopes-in-LMS-APIs.rst  # noqa E501 line too long
+# .. toggle_category: authorization
+# .. toggle_use_cases: incremental_release
+# .. toggle_creation_date: 2018-06-28
+# .. toggle_expiration_date: 2020-12-31
+# .. toggle_warnings: Toggle may be referenced from multiple IDAs.
+# .. toggle_tickets: ARCH-154
+# .. toggle_status: supported
+OAUTH_TOGGLE_NAMESPACE = 'oauth2'  # IMPORTANT: Constant is part of the public api.  Do NOT rename.
+SWITCH_ENFORCE_JWT_SCOPES = 'enforce_jwt_scopes'  # IMPORTANT: Constant is part of the public api.  Do NOT rename.
+NAMESPACED_SWITCH_ENFORCE_JWT_SCOPES = '{}.{}'.format(OAUTH_TOGGLE_NAMESPACE, SWITCH_ENFORCE_JWT_SCOPES)
 
 # .. toggle_name: EDX_DRF_EXTENSIONS[ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE]
 # .. toggle_implementation: DjangoSetting

--- a/edx_rest_framework_extensions/permissions.py
+++ b/edx_rest_framework_extensions/permissions.py
@@ -12,7 +12,7 @@ from edx_rest_framework_extensions.auth.jwt.decoder import (
     decode_jwt_is_restricted,
     decode_jwt_scopes,
 )
-from edx_rest_framework_extensions.config import SWITCH_ENFORCE_JWT_SCOPES
+from edx_rest_framework_extensions.config import NAMESPACED_SWITCH_ENFORCE_JWT_SCOPES
 
 
 log = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ class JwtRestrictedApplication(BasePermission):
 
     @classmethod
     def is_enforced_and_jwt_restricted_app(cls, request):
-        is_enforcement_enabled = waffle.switch_is_active(SWITCH_ENFORCE_JWT_SCOPES)
+        is_enforcement_enabled = waffle.switch_is_active(NAMESPACED_SWITCH_ENFORCE_JWT_SCOPES)
         ret_val = is_enforcement_enabled and is_jwt_authenticated(request) and decode_jwt_is_restricted(request.auth)
         log.debug(u"Permission JwtRestrictedApplication: returns %s.", ret_val)
         return ret_val


### PR DESCRIPTION
- restore public api toggle constants
- add permission of AllowAny to the csrf endpoint

The toggle constants for oauth scopes are used outside of
edx-drf-extensions (in edx-platform), so these constants must survive
and stay separate. NOTE: This problem was introduced in 2.4.2 while
edx-platform remained on 2.4.0. This will be fixed in edx-platform
while upgrading.

This fixes a csrf endpoint bug introduced into the 2.4.3 release,
where an IDA that had a default permission of DjangoModelPermissions
would start failing on this endpoint.

ARCH-1269