### PR TITLE
Switch from nose to pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ upgrade: upgrade-piptools piptools ## upgrade requirement pins.
 requirements: piptools ## install dev requirements into current env
 	pip-sync requirements/dev.txt
 
-test: ## run unit tests using tox
+test: ## run unit tests in all supported environments using tox
 	tox
 
 CHECK_DIRS=csrf edx_rest_framework_extensions
@@ -61,3 +61,6 @@ linting: ## check code quality with pylint
 
 quality: style isort_check linting ## run all code quality checks in current env
 	@echo "Quality checking complete!"
+
+test-python: ## run unit tests within this environment only
+	python -Wd -m pytest

--- a/edx_rest_framework_extensions/tests/test_paginators.py
+++ b/edx_rest_framework_extensions/tests/test_paginators.py
@@ -7,7 +7,6 @@ import ddt
 from django.http import Http404
 from django.test import RequestFactory
 from mock import MagicMock, Mock
-from nose.plugins.attrib import attr
 from rest_framework import serializers
 from six.moves import range  # pylint: disable=redefined-builtin
 
@@ -17,7 +16,6 @@ from edx_rest_framework_extensions.paginators import (
 )
 
 
-@attr(shard=2)
 @ddt.ddt
 class PaginateSearchResultsTestCase(TestCase):
     """Test cases for paginate_search_results method"""
@@ -128,7 +126,6 @@ class PaginateSearchResultsTestCase(TestCase):
             paginate_search_results(self.mock_model, self.search_results, self.default_size, page_num)
 
 
-@attr(shard=2)
 class NamespacedPaginationTestCase(TestCase):
     """
     Test behavior of `NamespacedPageNumberPagination`

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,6 +6,8 @@
 #
 alabaster==0.7.12
 astroid==1.6.6
+atomicwrites==1.3.0
+attrs==19.3.0
 babel==2.7.0
 backports.functools-lru-cache==1.6.1
 certifi==2019.11.28
@@ -16,7 +18,6 @@ configparser==4.0.2
 contextlib2==0.6.0.post1
 coverage==4.5.4
 ddt==1.2.2
-django-nose==1.4.6
 django-waffle==0.18.0
 django==1.11.26
 djangorestframework-jwt==1.11.0
@@ -44,7 +45,6 @@ mccabe==0.6.1
 mock==1.3.0
 more-itertools==5.0.0
 newrelic==5.4.0.132
-nose==1.3.7
 packaging==19.2
 pathlib2==2.3.5
 pbr==5.4.4
@@ -62,6 +62,9 @@ pylint-plugin-utils==0.6
 pylint==1.9.5
 pymongo==3.9.0
 pyparsing==2.4.5
+pytest-cov==2.8.1
+pytest-django==3.7.0
+pytest==4.6.6
 python-dateutil==2.8.1
 pytz==2019.3
 requests==2.22.0
@@ -80,6 +83,7 @@ tox==2.9.1
 typing==3.7.4.1
 urllib3==1.25.7
 virtualenv==16.7.8
+wcwidth==0.1.7
 wrapt==1.11.2
 zipp==0.6.0
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,10 +12,9 @@ jinja2==2.10.3            # via sphinx
 markupsafe==1.1.1         # via jinja2
 packaging==19.2           # via sphinx
 pygments==2.5.2           # via sphinx
-pyparsing==2.4.5          # via packaging
 pytz==2019.3              # via babel
 requests==2.22.0          # via sphinx
-six==1.13.0               # via packaging, sphinx
+six==1.13.0               # via sphinx
 snowballstemmer==2.0.0    # via sphinx
 sphinx-rtd-theme==0.4.3
 sphinx==1.8.5

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,7 +6,6 @@
 
 
 coverage>=4.0.3,<5.0.0
-django-nose>=1.4.3,<2.0.0
 ddt>=1.0.1,<2.0.0
 edx-lint
 isort
@@ -15,5 +14,7 @@ futures<=3.1.1
 httpretty>=0.8.14,<1.0.0
 mock>=1.3.0,<2.0.0
 pycodestyle
+pytest-cov
+pytest-django
 tox>=2.3.1,<3.0.0
 pyjwkest==1.3.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,6 +5,8 @@
 #    make upgrade
 #
 astroid==1.6.6            # via pylint, pylint-celery
+atomicwrites==1.3.0       # via pytest
+attrs==19.3.0             # via pytest
 backports.functools-lru-cache==1.6.1  # via astroid, isort, pylint
 certifi==2019.11.28
 chardet==3.0.4
@@ -14,7 +16,6 @@ configparser==4.0.2       # via importlib-metadata, pylint
 contextlib2==0.6.0.post1  # via importlib-metadata
 coverage==4.5.4
 ddt==1.2.2
-django-nose==1.4.6
 django-waffle==0.18.0
 djangorestframework-jwt==1.11.0
 djangorestframework==3.9.4
@@ -24,25 +25,25 @@ edx-opaque-keys==2.0.1
 enum34==1.1.6             # via astroid
 factory-boy==2.12.0
 faker==2.0.4              # via factory-boy
-funcsigs==1.0.2           # via mock
+funcsigs==1.0.2           # via mock, pytest
 future==0.18.2
 futures==3.1.1 ; python_version == "2.7"
 httpretty==0.9.7
 idna==2.8
-importlib-metadata==1.1.0  # via pluggy
+importlib-metadata==1.1.0  # via pluggy, pytest
 ipaddress==1.0.23         # via faker
 isort==4.3.21
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 mock==1.3.0
-more-itertools==5.0.0     # via zipp
+more-itertools==5.0.0     # via pytest, zipp
 newrelic==5.4.0.132
-nose==1.3.7               # via django-nose
-pathlib2==2.3.5           # via importlib-metadata
+packaging==19.2           # via pytest
+pathlib2==2.3.5           # via importlib-metadata, pytest, pytest-django
 pbr==5.4.4
-pluggy==0.13.1            # via tox
+pluggy==0.13.1            # via pytest, tox
 psutil==1.2.1
-py==1.8.0                 # via tox
+py==1.8.0                 # via pytest, tox
 pycodestyle==2.5.0
 pycryptodomex==3.9.4
 pyjwkest==1.3.2
@@ -52,6 +53,10 @@ pylint-django==0.11.1     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==1.9.5             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.9.0
+pyparsing==2.4.5          # via packaging
+pytest-cov==2.8.1
+pytest-django==3.7.0
+pytest==4.6.6             # via pytest-cov, pytest-django
 python-dateutil==2.8.1
 pytz==2019.3
 requests==2.22.0
@@ -65,5 +70,6 @@ text-unidecode==1.3       # via faker
 tox==2.9.1
 urllib3==1.25.7
 virtualenv==16.7.8        # via tox
+wcwidth==0.1.7            # via pytest
 wrapt==1.11.2             # via astroid
 zipp==0.6.0               # via importlib-metadata

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,8 @@ include_trailing_comma=True
 skip=
     settings
     migrations
+
+[tool:pytest]
+DJANGO_SETTINGS_MODULE = test_settings
+addopts = --cov csrf --cov edx_rest_framework_extensions --cov-report term-missing --cov-report html
+norecursedirs = .*  tests.py docs requirements

--- a/test_settings.py
+++ b/test_settings.py
@@ -13,7 +13,6 @@ INSTALLED_APPS = (
     'csrf.apps.CsrfAppConfig',
     'django.contrib.auth',
     'django.contrib.contenttypes',
-    'django_nose',
     'edx_rest_framework_extensions',
     'waffle',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     -r{toxinidir}/requirements/test.txt
 
 commands =
-    django-admin.py test {posargs:csrf edx_rest_framework_extensions} --settings=test_settings --with-coverage --cover-package=csrf,edx_rest_framework_extensions
+    python -Wd -m pytest {posargs}
     coverage report
 
 [testenv:quality]


### PR DESCRIPTION
While working on https://github.com/edx/edx-drf-extensions/pull/91, I got frustrated with the poor error messages and weaker CLI of nose as compared to pytest.

#99 moves us to pytest anyway, but I'm not sure when it will merge, so this PR pulls out the nose-to-pytest-specific changes so that they can merge on their own.

cc @Ayub-Khan , @jmbowman , @nedbat 