### PR TITLE
BOM-1324: remove oauth2.enforce_jwt_scopes toggle

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '2.4.6'  # pragma: no cover
+__version__ = '3.0.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/config.py
+++ b/edx_rest_framework_extensions/config.py
@@ -2,21 +2,6 @@
 Application configuration constants and code.
 """
 
-# .. toggle_name: oauth2.enforce_jwt_scopes
-# .. toggle_implementation: WaffleSwitch
-# .. toggle_default: False
-# .. toggle_description: Enforces JWT Scopes for an IDA. See https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0006-enforce-scopes-in-LMS-APIs.rst  # noqa E501 line too long
-# .. toggle_category: authorization
-# .. toggle_use_cases: incremental_release
-# .. toggle_creation_date: 2018-06-28
-# .. toggle_expiration_date: 2020-12-31
-# .. toggle_warnings: Toggle may be referenced from multiple IDAs.
-# .. toggle_tickets: ARCH-154
-# .. toggle_status: supported
-OAUTH_TOGGLE_NAMESPACE = 'oauth2'  # IMPORTANT: Constant is part of the public api.  Do NOT rename.
-SWITCH_ENFORCE_JWT_SCOPES = 'enforce_jwt_scopes'  # IMPORTANT: Constant is part of the public api.  Do NOT rename.
-NAMESPACED_SWITCH_ENFORCE_JWT_SCOPES = '{}.{}'.format(OAUTH_TOGGLE_NAMESPACE, SWITCH_ENFORCE_JWT_SCOPES)
-
 # .. toggle_name: EDX_DRF_EXTENSIONS[ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE]
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False


### PR DESCRIPTION
The oauth2.enforce_jwt_scopes waffle switch was added temporarily for
the rollout of JWT scopes. This removes the toggle and replaces it with
logic equivalent to setting `oauth2.enforce_jwt_scopes` to True.

BREAKING CHANGE:

This removes a toggle that may or may not have been set in any
particular environment, and was defaulted to False.

Before taking this upgrade:
* Make sure your IDA includes `EnsureJWTAuthSettingsMiddleware` in its
declared `MIDDLEWARE` or `MIDDLEWARE_CLASSES`.
* Although you could first check and/or set the
`oauth2.enforce_jwt_scopes` waffle switch to True in all environments
for your IDA, this upgrade is unlikely to cause an issue. If you want to
play it safe, setting the switch first is how you do it, but then you
need remove the switch.

After taking this upgrade:
* Once the upgrade has been deployed and is stable, delete the
`oauth2.enforce_jwt_scopes` waffle switch from all environments for the
IDA with the upgrade.