### PR TITLE
BOM-1098 Removing ENABLE_ANONYMOUS_ACCESS_ROLLOUT flag

### DIFF
--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -12,7 +12,6 @@ from rest_framework_jwt.authentication import (
 
 from edx_rest_framework_extensions.auth.jwt.constants import USE_JWT_COOKIE_HEADER
 from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler
-from edx_rest_framework_extensions.config import ENABLE_ANONYMOUS_ACCESS_ROLLOUT
 from edx_rest_framework_extensions.settings import get_setting
 
 
@@ -64,12 +63,6 @@ class JwtAuthentication(JSONWebTokenAuthentication):
     def authenticate(self, request):
         try:
             user_and_auth = super(JwtAuthentication, self).authenticate(request)
-
-            is_anonymous_access_rollout_enabled = get_setting(ENABLE_ANONYMOUS_ACCESS_ROLLOUT)
-            # Use Django Setting for rollout to coordinate with frontend-auth changes for
-            # anonymous access being available across MFEs.
-            if not is_anonymous_access_rollout_enabled:
-                return user_and_auth
 
             # Unauthenticated, CSRF validation not required
             if not user_and_auth:

--- a/edx_rest_framework_extensions/config.py
+++ b/edx_rest_framework_extensions/config.py
@@ -14,16 +14,3 @@ Application configuration constants and code.
 # .. toggle_tickets: ARCH-1210, ARCH-1199, ARCH-1197
 # .. toggle_status: supported
 ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE = 'ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE'
-
-# .. toggle_name: EDX_DRF_EXTENSIONS[ENABLE_ANONYMOUS_ACCESS_ROLLOUT]
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Toggle for enabling some functionality related to anonymous access
-# .. toggle_category: micro-frontend
-# .. toggle_use_cases: incremental_release
-# .. toggle_creation_date: 2019-11-06
-# .. toggle_expiration_date: 2019-12-31
-# .. toggle_warnings: Requires coordination with MFE updates of frontend-auth refactor.
-# .. toggle_tickets: ARCH-1229
-# .. toggle_status: supported
-ENABLE_ANONYMOUS_ACCESS_ROLLOUT = 'ENABLE_ANONYMOUS_ACCESS_ROLLOUT'

--- a/edx_rest_framework_extensions/settings.py
+++ b/edx_rest_framework_extensions/settings.py
@@ -15,10 +15,7 @@ import warnings
 from django.conf import settings
 from rest_framework_jwt.settings import api_settings
 
-from edx_rest_framework_extensions.config import (
-    ENABLE_ANONYMOUS_ACCESS_ROLLOUT,
-    ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE,
-)
+from edx_rest_framework_extensions.config import ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE
 
 
 logger = logging.getLogger(__name__)
@@ -34,7 +31,6 @@ DEFAULT_SETTINGS = {
     },
     'JWT_PAYLOAD_MERGEABLE_USER_ATTRIBUTES': (),
     ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE: False,
-    ENABLE_ANONYMOUS_ACCESS_ROLLOUT: False,
 }
 
 


### PR DESCRIPTION
ENABLE_ANONYMOUS_ACCESS_ROLLOUT flag was a temporarily used to facilitate rollout
of CSFR protection for MFEs. With that effort finished, the flag is no longer necessary
and is now being removed.