### PR TITLE
ARCHBOM-1036: fix for edx-drf-extensions 3.0.0

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '4.0.2'  # pragma: no cover
+__version__ = '4.0.3'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -9,7 +9,7 @@ from rest_framework import exceptions
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
 from edx_rest_framework_extensions.auth.jwt.constants import USE_JWT_COOKIE_HEADER
-from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler
+from edx_rest_framework_extensions.auth.jwt.decoder import configured_jwt_decode_handler
 from edx_rest_framework_extensions.settings import get_setting
 
 
@@ -187,4 +187,4 @@ def get_decoded_jwt_from_auth(request):
     if not is_jwt_authenticated(request):
         return None
 
-    return jwt_decode_handler(request.auth)
+    return configured_jwt_decode_handler(request.auth)

--- a/edx_rest_framework_extensions/auth/jwt/cookies.py
+++ b/edx_rest_framework_extensions/auth/jwt/cookies.py
@@ -4,7 +4,7 @@ JWT Authentication cookie utilities.
 
 from django.conf import settings
 
-from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler
+from edx_rest_framework_extensions.auth.jwt.decoder import configured_jwt_decode_handler
 
 
 def jwt_cookie_name():
@@ -30,4 +30,4 @@ def get_decoded_jwt(request):
 
     if not jwt_cookie:
         return None
-    return jwt_decode_handler(jwt_cookie)
+    return configured_jwt_decode_handler(jwt_cookie)

--- a/edx_rest_framework_extensions/auth/jwt/decoder.py
+++ b/edx_rest_framework_extensions/auth/jwt/decoder.py
@@ -44,6 +44,10 @@ def jwt_decode_handler(token):
                 'JWT_PUBLIC_SIGNING_JWK_SET': 'the-jwk-set-of-public-signing-keys',
             }
 
+    Warning:
+        Do **not** use this method internally.  Only use it in ``JWT_DECODE_HANDLER`` like the above example.
+        Internally, use ``configured_jwt_decode_handler`` which respects the ``JWT_DECODE_HANDLER`` setting.
+
     Args:
         token (str): JWT to be decoded.
 
@@ -60,18 +64,26 @@ def jwt_decode_handler(token):
     return _set_token_defaults(decoded_token)
 
 
+def configured_jwt_decode_handler(token):
+    """
+    Calls the ``jwt_decode_handler`` configured in the ``JWT_DECODE_HANDLER`` setting.
+    """
+    api_setting_jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
+    return api_setting_jwt_decode_handler(token)
+
+
 def decode_jwt_scopes(token):
     """
     Decode the JWT and return the scopes claim.
     """
-    return jwt_decode_handler(token).get('scopes', [])
+    return configured_jwt_decode_handler(token).get('scopes', [])
 
 
 def decode_jwt_is_restricted(token):
     """
     Decode the JWT and return the is_restricted claim.
     """
-    return jwt_decode_handler(token)['is_restricted']
+    return configured_jwt_decode_handler(token)['is_restricted']
 
 
 def decode_jwt_filters(token):
@@ -79,7 +91,7 @@ def decode_jwt_filters(token):
     Decode the JWT, parse the filters claim, and return a
     list of (filter_type, filter_value) tuples.
     """
-    return [jwt_filter.split(':') for jwt_filter in jwt_decode_handler(token)['filters']]
+    return [jwt_filter.split(':') for jwt_filter in configured_jwt_decode_handler(token)['filters']]
 
 
 def _set_token_defaults(token):


### PR DESCRIPTION
**NOTE:** Temporarily closing this PR. The plan is to first get this fix deployed as 3.0.1 off a release/3x branch, and then to bring that fix on to master and release again, probably as 4.0.3

See https://github.com/edx/edx-drf-extensions/pull/116 for 3.0.1 fix.

-----------------------

In 3.0.0, the switch `oauth2.enforce_jwt_scopes` was removed, which
starts checking is_restricted in JWTs and works fine for JWTs created
with the LMS, but was broken for ecommerce service JWTs which
were meant to be decoded with its own jwt_decode_handler.

This fix updates the JWT code to respect the JWT_DECODE_HANDLER setting
in JWT_AUTH, and uses the configured handler rather than assuming the
edx-drf-extensions version will always be used.

ARCHBOM-1036