### PR TITLE
ARCHBOM-1036: fix for edx-drf-extensions 3.0.0

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '3.0.0'  # pragma: no cover
+__version__ = '3.0.1'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -11,7 +11,7 @@ from rest_framework_jwt.authentication import (
 )
 
 from edx_rest_framework_extensions.auth.jwt.constants import USE_JWT_COOKIE_HEADER
-from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler
+from edx_rest_framework_extensions.auth.jwt.decoder import configured_jwt_decode_handler
 from edx_rest_framework_extensions.config import ENABLE_ANONYMOUS_ACCESS_ROLLOUT
 from edx_rest_framework_extensions.settings import get_setting
 
@@ -194,4 +194,4 @@ def get_decoded_jwt_from_auth(request):
     if not is_jwt_authenticated(request):
         return None
 
-    return jwt_decode_handler(request.auth)
+    return configured_jwt_decode_handler(request.auth)

--- a/edx_rest_framework_extensions/auth/jwt/cookies.py
+++ b/edx_rest_framework_extensions/auth/jwt/cookies.py
@@ -4,7 +4,7 @@ JWT Authentication cookie utilities.
 
 from django.conf import settings
 
-from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler
+from edx_rest_framework_extensions.auth.jwt.decoder import configured_jwt_decode_handler
 
 
 def jwt_cookie_name():
@@ -30,4 +30,4 @@ def get_decoded_jwt(request):
 
     if not jwt_cookie:
         return None
-    return jwt_decode_handler(jwt_cookie)
+    return configured_jwt_decode_handler(jwt_cookie)


### PR DESCRIPTION
In 3.0.0, the switch `oauth2.enforce_jwt_scopes` was removed, which
starts checking is_restricted in JWTs. This works fine for JWTs created
with the LMS, but uncovered a pre-existing bug that will only show
itself in the Ecommerce Service for certain JWTs which were meant to be
decoded with a custom jwt_decode_handler. In the Ecommerce Service only,
this custom jwt_decode_handler is set using the JWT_DECODE_HANDLER
setting.

This fix updates the JWT code to respect the JWT_DECODE_HANDLER setting
of JWT_AUTH, and uses the configured handler rather than assuming the
edx-drf-extensions version will always be used.

ARCHBOM-1036