### PR TITLE
release 4.0.4 as 5.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,4 @@ deploy:
   on:
     tags: true
     python: 3.5
-    condition: "$TOXENV = django111-drf39"
+    condition: "$TOXENV = django22-drf39"  # This env should NOT match the one used for AFTER_SUCCESS

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '4.0.4'  # pragma: no cover
+__version__ = '5.0.0'  # pragma: no cover


### PR DESCRIPTION
5.0.0 is the same release as 4.0.4. It is being released as its own
major version, because 4.0.1 had BREAKING CHANGES and should have been
its own release. This 5.0.0 version is simply being used to call
attention to the BREAKING CHANGES in 4.0.1.

NOTE: We will probably not go through the effort of releasing 4.0.5
to revert back to 4.0.0.

Additionally, the travis config was breaking on tagged releases because
it was trying to deploy twice. This should also fix that problem.