### PR TITLE
ARCHBOM-128: enhance authentication metrics

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '5.1.0'  # pragma: no cover
+__version__ = '6.0.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/tests/test_middleware.py
+++ b/edx_rest_framework_extensions/tests/test_middleware.py
@@ -6,6 +6,8 @@ from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory, TestCase
 from mock import call, patch
 
+from edx_rest_framework_extensions.auth.jwt.constants import USE_JWT_COOKIE_HEADER
+from edx_rest_framework_extensions.auth.jwt.cookies import jwt_cookie_name
 from edx_rest_framework_extensions.middleware import RequestMetricsMiddleware
 from edx_rest_framework_extensions.tests.factories import UserFactory
 
@@ -18,10 +20,17 @@ class TestRequestMetricsMiddleware(TestCase):
         self.middleware = RequestMetricsMiddleware()
 
     @patch('edx_django_utils.monitoring.set_custom_metric')
+    def test_request_auth_type_guess_anonymous_metric(self, mock_set_custom_metric):
+        self.request.user = AnonymousUser()
+
+        self.middleware.process_response(self.request, None)
+        mock_set_custom_metric.assert_called_once_with('request_auth_type_guess', 'unauthenticated')
+
+    @patch('edx_django_utils.monitoring.set_custom_metric')
     def test_request_no_headers(self, mock_set_custom_metric):
         self.request.user = None
         self.middleware.process_response(self.request, None)
-        mock_set_custom_metric.assert_called_once_with('request_auth_type', 'no-user')
+        mock_set_custom_metric.assert_called_once_with('request_auth_type_guess', 'no-user')
 
     @patch('edx_django_utils.monitoring.set_custom_metric')
     def test_request_blank_headers(self, mock_set_custom_metric):
@@ -30,7 +39,7 @@ class TestRequestMetricsMiddleware(TestCase):
         self.request.META['HTTP_AUTHORIZATION'] = ''
 
         self.middleware.process_response(self.request, None)
-        mock_set_custom_metric.assert_called_once_with('request_auth_type', 'no-user')
+        mock_set_custom_metric.assert_called_once_with('request_auth_type_guess', 'no-user')
 
     @patch('edx_django_utils.monitoring.set_custom_metric')
     def test_request_referer_metric(self, mock_set_custom_metric):
@@ -39,7 +48,7 @@ class TestRequestMetricsMiddleware(TestCase):
         self.middleware.process_response(self.request, None)
         expected_calls = [
             call('request_referer', 'test-http-referer'),
-            call('request_auth_type', 'no-user'),
+            call('request_auth_type_guess', 'no-user'),
         ]
         mock_set_custom_metric.assert_has_calls(expected_calls, any_order=True)
 
@@ -51,7 +60,7 @@ class TestRequestMetricsMiddleware(TestCase):
         expected_calls = [
             call('request_user_agent', 'python-requests/2.9.1 edx-rest-api-client/1.7.2 test-client'),
             call('request_client_name', 'test-client'),
-            call('request_auth_type', 'no-user'),
+            call('request_auth_type_guess', 'no-user'),
         ]
         mock_set_custom_metric.assert_has_calls(expected_calls, any_order=True)
 
@@ -62,7 +71,7 @@ class TestRequestMetricsMiddleware(TestCase):
         self.middleware.process_response(self.request, None)
         expected_calls = [
             call('request_user_agent', 'test-user-agent'),
-            call('request_auth_type', 'no-user'),
+            call('request_auth_type_guess', 'no-user'),
         ]
         mock_set_custom_metric.assert_has_calls(expected_calls, any_order=True)
 
@@ -73,25 +82,28 @@ class TestRequestMetricsMiddleware(TestCase):
     )
     @ddt.unpack
     @patch('edx_django_utils.monitoring.set_custom_metric')
-    def test_request_auth_type_token_metric(self, token, expected_token_type, mock_set_custom_metric):
+    def test_request_auth_type_guess_token_metric(self, token, expected_token_type, mock_set_custom_metric):
+        self.request.user = UserFactory()
         self.request.META['HTTP_AUTHORIZATION'] = token
 
         self.middleware.process_response(self.request, None)
-        mock_set_custom_metric.assert_called_once_with('request_auth_type', expected_token_type)
+        mock_set_custom_metric.assert_any_call('request_auth_type_guess', expected_token_type)
 
     @patch('edx_django_utils.monitoring.set_custom_metric')
-    def test_request_auth_type_anonymous_metric(self, mock_set_custom_metric):
-        self.request.user = AnonymousUser()
+    def test_request_auth_type_guess_jwt_cookie_metric(self, mock_set_custom_metric):
+        self.request.user = UserFactory()
+        self.request.META[USE_JWT_COOKIE_HEADER] = True
+        self.request.COOKIES[jwt_cookie_name()] = 'reconstituted-jwt-cookie'
 
         self.middleware.process_response(self.request, None)
-        mock_set_custom_metric.assert_called_once_with('request_auth_type', 'unauthenticated')
+        mock_set_custom_metric.assert_any_call('request_auth_type_guess', 'jwt-cookie')
 
     @patch('edx_django_utils.monitoring.set_custom_metric')
-    def test_request_auth_type_session_metric(self, mock_set_custom_metric):
+    def test_request_auth_type_guess_session_metric(self, mock_set_custom_metric):
         self.request.user = UserFactory()
 
         self.middleware.process_response(self.request, None)
-        mock_set_custom_metric.assert_any_call('request_auth_type', 'session-or-unknown')
+        mock_set_custom_metric.assert_any_call('request_auth_type_guess', 'session-or-other')
 
     @patch('edx_django_utils.monitoring.set_custom_metric')
     def test_request_user_id_metric(self, mock_set_custom_metric):
@@ -99,3 +111,36 @@ class TestRequestMetricsMiddleware(TestCase):
 
         self.middleware.process_response(self.request, None)
         mock_set_custom_metric.assert_any_call('request_user_id', self.request.user.id)
+        mock_set_custom_metric.assert_any_call(
+            'request_authenticated_user_found_in_middleware', 'process_response'
+        )
+
+    @patch('edx_django_utils.monitoring.set_custom_metric')
+    def test_request_user_id_metric_with_exception(self, mock_set_custom_metric):
+        self.request.user = UserFactory()
+
+        self.middleware.process_exception(self.request, None)
+        mock_set_custom_metric.assert_any_call('request_user_id', self.request.user.id)
+        mock_set_custom_metric.assert_any_call(
+            'request_authenticated_user_found_in_middleware', 'process_exception'
+        )
+
+    @patch('edx_django_utils.monitoring.set_custom_metric')
+    def test_authenticated_user_found_in_process_request(self, mock_set_custom_metric):
+        self.request.user = UserFactory()
+        self.middleware.process_request(self.request)
+        self.middleware.process_response(self.request, None)
+
+        mock_set_custom_metric.assert_any_call(
+            'request_authenticated_user_found_in_middleware', 'process_request'
+        )
+
+    @patch('edx_django_utils.monitoring.set_custom_metric')
+    def test_authenticated_user_found_in_process_view(self, mock_set_custom_metric):
+        self.request.user = UserFactory()
+        self.middleware.process_view(self.request, None, None, None)
+        self.middleware.process_response(self.request, None)
+
+        mock_set_custom_metric.assert_any_call(
+            'request_authenticated_user_found_in_middleware', 'process_view'
+        )


### PR DESCRIPTION
BREAKING CHANGE: Changed names of NewRelic metric names and values.
  Has potential to break NewRelic dashboards or alerts, but should not
  have an affect on deployed code.

- Renamed 'request_auth_type' to 'request_auth_type_guess'. This makes
  it more clear that this metric could be wrong in certain cases.
- Renamed value `session-or-unknown` to `session-or-other`. This name
  makes it more clear that it is the method of authentication that is in
  question, not whether or not the user is authenticated.
- Added 'jwt-cookie' as new value for 'request_auth_type_guess'.
- Added new 'request_authenticated_user_found_in_middleware' metric.
  Helps identify for what middleware step the request user was set, if
  it was set. Example values: 'process_request', 'process_view',
  'process_response', or 'process_exception'.
- Fixed/Added setting of authentication metrics for exceptions as well.
- Fixed values of 'unauthenticated' and 'no-user' for
  'request_auth_type_guess' to be more accurate.

ARCHBOM-128