### PR TITLE
ARCHBOM-128 fix request_authenticated_user_found_in_middleware bug

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '6.0.0'  # pragma: no cover
+__version__ = '6.0.1'  # pragma: no cover


### PR DESCRIPTION
The request metric request_authenticated_user_found_in_middleware was
not getting reset for each request. This fixes the issue by using the
request cache.

ARCHBOM-128