### PR TITLE
ARCHBOM-1213: add changelog to edx-drf-extensions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+**Description:**
+
+Describe in a couple of sentences what this PR adds
+
+**JIRA:**
+
+[XXX-XXXX](https://openedx.atlassian.net/browse/XXX-XXXX)
+
+**Additional Details**
+
+* **Dependencies:**: List dependencies on other outstanding PRs, issues, etc.
+* **Merge deadline:** List merge deadline (if any)
+* **Testing instructions:** Provide non-trivial testing instructions
+* **Author concerns:** List any concerns about this PR
+
+**Reviewers:**
+- [ ] @edx/arch-review
+- [ ] tag reviewer
+
+**Merge checklist:**
+- [ ] All reviewers approved
+- [ ] CI build is green
+- [ ] Version bump if needed
+- [ ] Changelog record added
+- [ ] Documentation updated (not only docstrings)
+- [ ] Commits are squashed
+
+**Post merge:**
+- [ ] Create a tag
+- [ ] Check new version is pushed to PyPi after tag-triggered build is 
+      finished.
+- [ ] Delete working branch (if not needed anymore)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,36 @@
+Change Log
+==========
+
+..
+   This file loosely adheres to the structure of https://keepachangelog.com/,
+   but in reStructuredText instead of Markdown.
+
+   This project adheres to Semantic Versioning (https://semver.org/).
+
+.. There should always be an "Unreleased" section for changes pending release.
+
+Unreleased
+----------
+
+*
+
+[6.0.0] - 2020-05-05
+--------------------
+
+Changed
+~~~~~~~
+
+* **BREAKING CHANGE**: Renamed 'request_auth_type' to 'request_auth_type_guess'. This makes it more clear that this metric could report the wrong value in certain cases. This could break dashboards or alerts that relied on this metric.
+* **BREAKING CHANGE**: Renamed value `session-or-unknown` to `session-or-other`. This name makes it more clear that it is the method of authentication that is in question, not whether or not the user is authenticated. This could break dashboards or alerts that relied on this metric.
+
+Added
+~~~~~
+
+* Added 'jwt-cookie' as new value for 'request_auth_type_guess'.
+* Added new 'request_authenticated_user_found_in_middleware' metric. Helps identify for what middleware step the request user was set, if it was set. Example values: 'process_request', 'process_view', 'process_response', or 'process_exception'.
+
+Fixed
+~~~~~
+
+* Fixed/Added setting of authentication metrics for exceptions as well.
+* Fixed 'request_auth_type_guess' to be more accurate when recording values of 'unauthenticated' and 'no-user'.

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,16 @@ This library includes various cross-cutting concerns related to APIs. API functi
 
 Some of these concerns include extensions of `Django REST Framework <http://www.django-rest-framework.org/>`_ (DRF), which is how the repository initially got its name.
 
+Publishing a Release
+--------------------
+
+After a PR merges, a new version of the package will automatically be released by Travis when the commit is tagged. Use::
+
+    git tag -a X.Y.Z -m "Releasing version X.Y.Z"
+    git push origin X.Y.Z
+
+Do **not** create a Github Release, or ensure its message points to the CHANGELOG.rst and ADR 0002-use-changelog.rst.
+
 JWT Authentication and REST API Endpoints
 -----------------------------------------
 
@@ -52,10 +62,3 @@ Reporting Security Issues
 -------------------------
 
 Please do not report security issues in public. Please email security@edx.org.
-
-Mailing List and IRC Channel
-----------------------------
-
-You can discuss this code in the `edx-code Google Group`__ or in the ``#edx-code`` IRC channel on Freenode.
-
-__ https://groups.google.com/forum/#!forum/edx-code

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,1 @@
+.. include:: ../CHANGELOG.rst

--- a/docs/decisions/0001-use-changelog.rst
+++ b/docs/decisions/0001-use-changelog.rst
@@ -1,0 +1,70 @@
+1. Use CHANGELOG.rst
+====================
+
+Status
+------
+
+Accepted
+
+Context
+-------
+
+This repository was using Github Releases only to capture changelog details, which has the following issues:
+
+* Additions and updates to the changelog don't go through PR review.
+* The changelog is not versioned with the repository, is not available with the repo documentation, cannot be seen in a single file, and is not available offline.
+
+Additionally, there was no guidance for formatting entries.
+
+Decision
+--------
+
+* Add a CHANGELOG.rst as the primary source of tracking changes.
+* The changelog will be formatted according to `keepachangelog.com`_.
+* Avoid redundancy in Github Releases.
+
+This resolves all issues noted under this ADR's `Context`_.
+
+Commit Message vs Changelog Entry
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since changelog messages are for developers and consumers of your code, good changelog messages will often not match commit messages. Here are some examples:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - Commit Message
+     - Changelog Entry
+   * - deps: update dependency some-dependency to 2.3.0
+     - No functional change
+
+       Note: This example changelog entry assumes there were no other changes for this version.
+   * - Fix SyntaxError in UserLogout class
+     - Fix 500 error during logout
+   * - Rename dry_run parameter
+     - **BREAKING CHANGE** Remove the dry_run parameter in the public foobarize API method. This parameter is deprecated in favour of the no_apply parameter. See docs for details.
+   * - Add set_foobarizer method to api.Foo
+     - Add a set_foobarizer method to Foo's public API. This is particularly useful for developers trying to foobarize their users. See docs for details.
+
+Consequences
+------------
+
+Regarding the discontinuation of using Github Releases:
+
+* Writing the changelog entry in the CHANGELOG.rst should be as simple as it was to write it in Github Releases, so there should be no additional work.
+* The README.rst should be updated regarding the proper way to release to avoid Github Release redundancy.
+* Older Github Release messages could one day be relocated to the CHANGELOG.rst.  For now, the latest release message should clarify the change in policy and point to the CHANELOG.rst.
+
+Additional tools:
+
+* A Pull Request template will be added to provide a reminder.
+
+References
+----------
+
+* `keepachangelog.com`_
+* `OEP-47: Semantic Versioning`_ (Coming Soon)
+
+.. _keepachangelog.com: https://keepachangelog.com/en/1.0.0/
+.. _`OEP-47: Semantic Versioning`: https://open-edx-proposals.readthedocs.io/en/latest/oep-0047-bp-semantic-versioning.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,3 +33,4 @@ Table of Contents
     middleware
     permissions
     utils
+    changelog


### PR DESCRIPTION
ARCHBOM-1213

Post-merge:
- [ ] Update https://github.com/edx/edx-drf-extensions/releases/tag/6.0.0
  * Should point to CHANGELOG.rst and ADR and clarify that Github Releases should no longer be used. Could point to the README.rst for publishing instructions.
