### PR TITLE
ARCHBOM-1293 Upstream drf-jwt issue should be fixed.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,22 @@ Unreleased
 
 *
 
+[6.1.0] - 2020-06-26
+--------------------
+
+Changed
+~~~~~~~
+
+* Update `drf-jwt` to pull in new allow-list(they called it blacklist) feature.
+
+Added
+~~~~~
+
+Fixed
+~~~~~
+
+
+
 [6.0.0] - 2020-05-05
 --------------------
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '6.0.1'  # pragma: no cover
+__version__ = '6.1.0'  # pragma: no cover

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,8 +2,7 @@
 
 Django>=2.2
 djangorestframework>=3.2.0
-drf-jwt<1.15.0  # max contraint added here to work with setup.py's `install_requires`.
-                # for explanation of 1.15.0 constraint, see https://github.com/edx/edx-drf-extensions/releases/tag/5.0.1
+drf-jwt
 django-waffle
 edx-django-utils
 edx-opaque-keys

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,29 +4,32 @@
 #
 #    make upgrade
 #
-certifi==2020.4.5.1       # via requests
+certifi==2020.6.20        # via requests
+cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
-django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils
-django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, djangorestframework, drf-jwt, edx-django-utils, rest-condition
+cryptography==2.9.2       # via pyjwt
+django-waffle==1.0.0      # via -r requirements/base.in, edx-django-utils
+django==2.2.13            # via -c requirements/constraints.txt, -r requirements/base.in, djangorestframework, drf-jwt, edx-django-utils, rest-condition
 djangorestframework==3.11.0  # via -r requirements/base.in, drf-jwt, rest-condition
-drf-jwt==1.14.0           # via -r requirements/base.in
-edx-django-utils==3.2.2   # via -r requirements/base.in
+drf-jwt==1.16.2           # via -r requirements/base.in
+edx-django-utils==3.2.3   # via -r requirements/base.in
 edx-opaque-keys==2.1.0    # via -r requirements/base.in
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests
-newrelic==5.12.1.141      # via edx-django-utils
+newrelic==5.14.1.144      # via edx-django-utils
 pbr==5.4.5                # via stevedore
 psutil==1.2.1             # via edx-django-utils
-pycryptodomex==3.9.7      # via pyjwkest
+pycparser==2.20           # via cffi
+pycryptodomex==3.9.8      # via pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.in
-pyjwt==1.7.1              # via drf-jwt
+pyjwt[crypto]==1.7.1      # via drf-jwt
 pymongo==3.10.1           # via edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.in
 pytz==2020.1              # via django
-requests==2.23.0          # via -r requirements/base.in, pyjwkest
+requests==2.24.0          # via -r requirements/base.in, pyjwkest
 rest-condition==1.0.3     # via -r requirements/base.in
 semantic-version==2.8.5   # via -r requirements/base.in
-six==1.15.0               # via -r requirements/base.in, django-waffle, edx-opaque-keys, pyjwkest, python-dateutil, stevedore
+six==1.15.0               # via -r requirements/base.in, cryptography, edx-opaque-keys, pyjwkest, python-dateutil, stevedore
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
 urllib3==1.25.9           # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,67 +9,70 @@ appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via -r requirements/docs.txt, sphinx
-certifi==2020.4.5.1       # via -r requirements/base.txt, -r requirements/docs.txt, -r requirements/test.txt, requests
+certifi==2020.6.20        # via -r requirements/base.txt, -r requirements/docs.txt, -r requirements/test.txt, requests
+cffi==1.14.0              # via -r requirements/base.txt, -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, -r requirements/docs.txt, -r requirements/test.txt, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, edx-lint
 coverage==4.5.4           # via -r requirements/test.txt, pytest-cov
+cryptography==2.9.2       # via -r requirements/base.txt, -r requirements/test.txt, pyjwt
 ddt==1.4.1                # via -r requirements/test.txt
 distlib==0.3.0            # via -r requirements/test.txt, virtualenv
-django-waffle==0.20.0     # via -r requirements/base.txt, -r requirements/test.txt, edx-django-utils
-django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.txt, -r requirements/test.txt, djangorestframework, drf-jwt, edx-django-utils, rest-condition
+django-waffle==1.0.0      # via -r requirements/base.txt, -r requirements/test.txt, edx-django-utils
+django==2.2.13            # via -c requirements/constraints.txt, -r requirements/base.txt, -r requirements/test.txt, djangorestframework, drf-jwt, edx-django-utils, rest-condition
 djangorestframework==3.11.0  # via -r requirements/base.txt, -r requirements/test.txt, drf-jwt, rest-condition
 docutils==0.16            # via -r requirements/docs.txt, sphinx
-drf-jwt==1.14.0           # via -r requirements/base.txt, -r requirements/test.txt
-edx-django-utils==3.2.2   # via -r requirements/base.txt, -r requirements/test.txt
+drf-jwt==1.16.2           # via -r requirements/base.txt, -r requirements/test.txt
+edx-django-utils==3.2.3   # via -r requirements/base.txt, -r requirements/test.txt
 edx-lint==1.4.1           # via -r requirements/test.txt
 edx-opaque-keys==2.1.0    # via -r requirements/base.txt, -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
-faker==4.1.0              # via -r requirements/test.txt, factory-boy
+faker==4.1.1              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, virtualenv
 future==0.18.2            # via -r requirements/base.txt, -r requirements/test.txt, pyjwkest
 httpretty==0.9.7          # via -r requirements/test.txt
 idna==2.9                 # via -r requirements/base.txt, -r requirements/docs.txt, -r requirements/test.txt, requests
 imagesize==1.2.0          # via -r requirements/docs.txt, sphinx
-importlib-metadata==1.6.0  # via -r requirements/test.txt, importlib-resources, pluggy, pytest, virtualenv
-importlib-resources==1.5.0  # via -r requirements/test.txt, virtualenv
+importlib-metadata==1.6.1  # via -r requirements/test.txt, importlib-resources, pluggy, pytest, virtualenv
+importlib-resources==2.0.1  # via -r requirements/test.txt, virtualenv
 isort==4.3.21             # via -r requirements/test.txt, pylint
 jinja2==2.11.2            # via -r requirements/docs.txt, sphinx
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via -r requirements/docs.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==1.3.0               # via -r requirements/test.txt
-more-itertools==8.3.0     # via -r requirements/test.txt, pytest
-newrelic==5.12.1.141      # via -r requirements/base.txt, -r requirements/test.txt, edx-django-utils
+more-itertools==8.4.0     # via -r requirements/test.txt, pytest
+newrelic==5.14.1.144      # via -r requirements/base.txt, -r requirements/test.txt, edx-django-utils
 packaging==20.4           # via -r requirements/docs.txt, -r requirements/test.txt, pytest, sphinx
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/base.txt, -r requirements/test.txt, mock, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 psutil==1.2.1             # via -r requirements/base.txt, -r requirements/test.txt, edx-django-utils
-py==1.8.1                 # via -r requirements/test.txt, pytest, tox
+py==1.9.0                 # via -r requirements/test.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/test.txt
-pycryptodomex==3.9.7      # via -r requirements/base.txt, -r requirements/test.txt, pyjwkest
+pycparser==2.20           # via -r requirements/base.txt, -r requirements/test.txt, cffi
+pycryptodomex==3.9.8      # via -r requirements/base.txt, -r requirements/test.txt, pyjwkest
 pygments==2.6.1           # via -r requirements/docs.txt, sphinx
 pyjwkest==1.4.2           # via -r requirements/base.txt, -r requirements/test.txt
-pyjwt==1.7.1              # via -r requirements/base.txt, -r requirements/test.txt, drf-jwt
+pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, -r requirements/test.txt, drf-jwt
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
 pylint==2.4.2             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/base.txt, -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/docs.txt, -r requirements/test.txt, packaging
-pytest-cov==2.9.0         # via -r requirements/test.txt
+pytest-cov==2.10.0        # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==5.4.2             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, -r requirements/test.txt, faker
 pytz==2020.1              # via -r requirements/base.txt, -r requirements/docs.txt, -r requirements/test.txt, babel, django
-requests==2.23.0          # via -r requirements/base.txt, -r requirements/docs.txt, -r requirements/test.txt, pyjwkest, sphinx
+requests==2.24.0          # via -r requirements/base.txt, -r requirements/docs.txt, -r requirements/test.txt, pyjwkest, sphinx
 rest-condition==1.0.3     # via -r requirements/base.txt, -r requirements/test.txt
 semantic-version==2.8.5   # via -r requirements/base.txt, -r requirements/test.txt
-six==1.15.0               # via -r requirements/base.txt, -r requirements/docs.txt, -r requirements/test.txt, astroid, django-waffle, edx-lint, edx-opaque-keys, httpretty, mock, packaging, pathlib2, pyjwkest, python-dateutil, stevedore, tox, virtualenv
+six==1.15.0               # via -r requirements/base.txt, -r requirements/docs.txt, -r requirements/test.txt, astroid, cryptography, edx-lint, edx-opaque-keys, httpretty, mock, packaging, pathlib2, pyjwkest, python-dateutil, stevedore, tox, virtualenv
 snowballstemmer==2.0.0    # via -r requirements/docs.txt, sphinx
-sphinx-rtd-theme==0.4.3   # via -r requirements/docs.txt
-sphinx==3.0.4             # via -r requirements/docs.txt, sphinx-rtd-theme
+sphinx-rtd-theme==0.5.0   # via -r requirements/docs.txt
+sphinx==3.1.1             # via -r requirements/docs.txt, sphinx-rtd-theme
 sphinxcontrib-applehelp==1.0.2  # via -r requirements/docs.txt, sphinx
 sphinxcontrib-devhelp==1.0.2  # via -r requirements/docs.txt, sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via -r requirements/docs.txt, sphinx
@@ -82,8 +85,8 @@ text-unidecode==1.3       # via -r requirements/test.txt, faker
 tox==2.9.1                # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 urllib3==1.25.9           # via -r requirements/base.txt, -r requirements/docs.txt, -r requirements/test.txt, requests
-virtualenv==20.0.21       # via -r requirements/test.txt, tox
-wcwidth==0.1.9            # via -r requirements/test.txt, pytest
+virtualenv==20.0.25       # via -r requirements/test.txt, tox
+wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata, importlib-resources
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12         # via sphinx
 babel==2.8.0              # via sphinx
-certifi==2020.4.5.1       # via -c requirements/test.txt, requests
+certifi==2020.6.20        # via -c requirements/test.txt, requests
 chardet==3.0.4            # via -c requirements/test.txt, requests
 docutils==0.16            # via sphinx
 idna==2.9                 # via -c requirements/test.txt, requests
@@ -17,11 +17,11 @@ packaging==20.4           # via -c requirements/test.txt, sphinx
 pygments==2.6.1           # via sphinx
 pyparsing==2.4.7          # via -c requirements/test.txt, packaging
 pytz==2020.1              # via -c requirements/test.txt, babel
-requests==2.23.0          # via -c requirements/test.txt, sphinx
+requests==2.24.0          # via -c requirements/test.txt, sphinx
 six==1.15.0               # via -c requirements/test.txt, packaging
 snowballstemmer==2.0.0    # via sphinx
-sphinx-rtd-theme==0.4.3   # via -r requirements/docs.in
-sphinx==3.0.4             # via -r requirements/docs.in, sphinx-rtd-theme
+sphinx-rtd-theme==0.5.0   # via -r requirements/docs.in
+sphinx==3.1.1             # via -r requirements/docs.in, sphinx-rtd-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.2.0          # via -r requirements/pip-tools.in
+pip-tools==5.2.1          # via -r requirements/pip-tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,64 +7,67 @@
 appdirs==1.4.4            # via virtualenv
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
-certifi==2020.4.5.1       # via -r requirements/base.txt, requests
+certifi==2020.6.20        # via -r requirements/base.txt, requests
+cffi==1.14.0              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 coverage==4.5.4           # via -r requirements/test.in, pytest-cov
+cryptography==2.9.2       # via -r requirements/base.txt, pyjwt
 ddt==1.4.1                # via -r requirements/test.in
 distlib==0.3.0            # via virtualenv
-django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils
-drf-jwt==1.14.0           # via -r requirements/base.txt
-edx-django-utils==3.2.2   # via -r requirements/base.txt
+django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils
+drf-jwt==1.16.2           # via -r requirements/base.txt
+edx-django-utils==3.2.3   # via -r requirements/base.txt
 edx-lint==1.4.1           # via -r requirements/test.in
 edx-opaque-keys==2.1.0    # via -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/test.in
-faker==4.1.0              # via factory-boy
+faker==4.1.1              # via factory-boy
 filelock==3.0.12          # via virtualenv
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 httpretty==0.9.7          # via -r requirements/test.in
 idna==2.9                 # via -r requirements/base.txt, requests
-importlib-metadata==1.6.0  # via importlib-resources, pluggy, pytest, virtualenv
-importlib-resources==1.5.0  # via virtualenv
+importlib-metadata==1.6.1  # via importlib-resources, pluggy, pytest, virtualenv
+importlib-resources==2.0.1  # via virtualenv
 isort==4.3.21             # via -r requirements/test.in, pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 mock==1.3.0               # via -r requirements/test.in
-more-itertools==8.3.0     # via pytest
-newrelic==5.12.1.141      # via -r requirements/base.txt, edx-django-utils
+more-itertools==8.4.0     # via pytest
+newrelic==5.14.1.144      # via -r requirements/base.txt, edx-django-utils
 packaging==20.4           # via pytest
 pathlib2==2.3.5           # via pytest
 pbr==5.4.5                # via -r requirements/base.txt, mock, stevedore
 pluggy==0.13.1            # via pytest, tox
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
-py==1.8.1                 # via pytest, tox
+py==1.9.0                 # via pytest, tox
 pycodestyle==2.6.0        # via -r requirements/test.in
-pycryptodomex==3.9.7      # via -r requirements/base.txt, pyjwkest
+pycparser==2.20           # via -r requirements/base.txt, cffi
+pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt
-pyjwt==1.7.1              # via -r requirements/base.txt, drf-jwt
+pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via packaging
-pytest-cov==2.9.0         # via -r requirements/test.in
+pytest-cov==2.10.0        # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
-pytest==5.4.2             # via pytest-cov, pytest-django
+pytest==5.4.3             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, faker
 pytz==2020.1              # via -r requirements/base.txt, django
-requests==2.23.0          # via -r requirements/base.txt, pyjwkest
+requests==2.24.0          # via -r requirements/base.txt, pyjwkest
 rest-condition==1.0.3     # via -r requirements/base.txt
 semantic-version==2.8.5   # via -r requirements/base.txt
-six==1.15.0               # via -r requirements/base.txt, astroid, django-waffle, edx-lint, edx-opaque-keys, httpretty, mock, packaging, pathlib2, pyjwkest, python-dateutil, stevedore, tox, virtualenv
+six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, edx-lint, edx-opaque-keys, httpretty, mock, packaging, pathlib2, pyjwkest, python-dateutil, stevedore, tox, virtualenv
 sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
 text-unidecode==1.3       # via faker
 tox==2.9.1                # via -r requirements/test.in
 typed-ast==1.4.1          # via astroid
 urllib3==1.25.9           # via -r requirements/base.txt, requests
-virtualenv==20.0.21       # via tox
-wcwidth==0.1.9            # via pytest
+virtualenv==20.0.25       # via tox
+wcwidth==0.2.5            # via pytest
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
Unpinning drf-jwt now that
https://github.com/Styria-Digital/django-rest-framework-jwt/issues/40 is
resolved.

Bump the minor version beacuse the update to drf-jwt brings in new
blacklist functionality.

**Description:**

Describe in a couple of sentences what this PR adds

**Reviewers:**
- [ ] @edx/arch-review
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bump if needed
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
