### PR TITLE
Reorganize and clarify permission classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,14 +22,16 @@ Changed
 
 * Refactored a large permissions.py module into multiple modules within a new permissions folder in order to clarify the different sets of permissions for their different purposes. In particular, separated Permissions related to enforcing OAuth Scopes and Restricted Applications from other Basic permissions in order to avoid confusion on which permissions to use for basic functionality.
 
+* To continue to support clients who imported permissions from the old permissions.py module, those permissions are exported from the permissions/__init__.py module for backward compatibility (with the following caveat). *(Note: This works since Python's import statement is the same whether the code is imported from a module named XXX or from an __init__.py module in a directory named XXX.)*
+
+* **BREAKING CHANGE** All permissions moved into the oauth_scopes.py module are *not* exported from the permissions/__init__.py module since these permissions are not expected to be used widely and far in the future. The only clients of these permissions are in edx-platform, which will be updated once these changes are released.
+
 Added
 ~~~~~
 
 * Created a new permissions folder for containing and organizing Permission classes.
 * Created new permissions-related modules: basic.py, oauth_scopes.py, and redirect.py.
 
-Fixed
-~~~~~
 
 [6.1.0] - 2020-06-26
 --------------------
@@ -38,13 +40,6 @@ Changed
 ~~~~~~~
 
 * Update `drf-jwt` to pull in new allow-list(they called it blacklist) feature.
-
-Added
-~~~~~
-
-Fixed
-~~~~~
-
 
 
 [6.0.0] - 2020-05-05

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,23 @@ Unreleased
 
 *
 
+[7.0.0] - 2020-07-15
+--------------------
+
+Changed
+~~~~~~~
+
+* Refactored a large permissions.py module into multiple modules within a new permissions folder in order to clarify the different sets of permissions for their different purposes. In particular, Permissions related to enforcing OAuth Scopes and Restricted Applications were intermixed with other Basic permissions, which added confusion on what needed to be used.
+
+Added
+~~~~~
+
+* Created a new permissions folder for containing and organizing Permission classes.
+* Created a new permissions-related modules: basic.py, oauth_scopes.py, and redirect.py.
+
+Fixed
+~~~~~
+
 [6.1.0] - 2020-06-26
 --------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,13 +20,13 @@ Unreleased
 Changed
 ~~~~~~~
 
-* Refactored a large permissions.py module into multiple modules within a new permissions folder in order to clarify the different sets of permissions for their different purposes. In particular, Permissions related to enforcing OAuth Scopes and Restricted Applications were intermixed with other Basic permissions, which added confusion on what needed to be used.
+* Refactored a large permissions.py module into multiple modules within a new permissions folder in order to clarify the different sets of permissions for their different purposes. In particular, separated Permissions related to enforcing OAuth Scopes and Restricted Applications from other Basic permissions in order to avoid confusion on which permissions to use for basic functionality.
 
 Added
 ~~~~~
 
 * Created a new permissions folder for containing and organizing Permission classes.
-* Created a new permissions-related modules: basic.py, oauth_scopes.py, and redirect.py.
+* Created new permissions-related modules: basic.py, oauth_scopes.py, and redirect.py.
 
 Fixed
 ~~~~~

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '6.1.0'  # pragma: no cover
+__version__ = '7.0.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/permissions/__init__.py
+++ b/edx_rest_framework_extensions/permissions/__init__.py
@@ -1,0 +1,7 @@
+# Support backward compatibility of imports prior to creating a permissions directory
+from .redirect import LoginRedirectIfUnauthenticated
+from .basic import (
+  IsSuperuser,
+  IsStaff,
+  IsUserInUrl
+)

--- a/edx_rest_framework_extensions/permissions/basic.py
+++ b/edx_rest_framework_extensions/permissions/basic.py
@@ -1,0 +1,33 @@
+""" Basic Permission classes. """
+import logging
+from rest_framework.permissions import BasePermission
+from edx_rest_framework_extensions.utils import get_username_param
+
+
+log = logging.getLogger(__name__)
+
+
+class IsSuperuser(BasePermission):
+    """ Allows access only to superusers. """
+
+    def has_permission(self, request, view):
+        return request.user and request.user.is_superuser
+
+
+class IsStaff(BasePermission):
+    """
+    Allows access to "global" staff users..
+    """
+    def has_permission(self, request, view):
+        return request.user.is_staff
+
+
+class IsUserInUrl(BasePermission):
+    """
+    Allows access if the requesting user matches the user in the URL.
+    """
+    def has_permission(self, request, view):
+        allowed = request.user.username.lower() == get_username_param(request)
+        if not allowed:
+            log.info(u"Permission IsUserInUrl: not satisfied for requesting user %s.", request.user.username)
+        return allowed

--- a/edx_rest_framework_extensions/permissions/oauth_scopes.py
+++ b/edx_rest_framework_extensions/permissions/oauth_scopes.py
@@ -6,9 +6,9 @@ https://github.com/edx/edx-platform/tree/master/openedx/core/djangoapps/oauth_di
 """
 import logging
 
+from opaque_keys.edx.keys import CourseKey
 from rest_condition import C
 from rest_framework.permissions import BasePermission, IsAuthenticated
-from opaque_keys.edx.keys import CourseKey
 
 from edx_rest_framework_extensions.permissions.basic import IsStaff, IsUserInUrl
 

--- a/edx_rest_framework_extensions/permissions/oauth_scopes.py
+++ b/edx_rest_framework_extensions/permissions/oauth_scopes.py
@@ -10,14 +10,13 @@ from opaque_keys.edx.keys import CourseKey
 from rest_condition import C
 from rest_framework.permissions import BasePermission, IsAuthenticated
 
-from edx_rest_framework_extensions.permissions.basic import IsStaff, IsUserInUrl
-
 from edx_rest_framework_extensions.auth.jwt.authentication import is_jwt_authenticated
 from edx_rest_framework_extensions.auth.jwt.decoder import (
     decode_jwt_filters,
     decode_jwt_is_restricted,
     decode_jwt_scopes,
 )
+from edx_rest_framework_extensions.permissions.basic import IsStaff, IsUserInUrl
 from edx_rest_framework_extensions.utils import get_username_param
 
 

--- a/edx_rest_framework_extensions/permissions/redirect.py
+++ b/edx_rest_framework_extensions/permissions/redirect.py
@@ -1,0 +1,17 @@
+"""
+Permission classes related to redirect functionality required by JwtRedirectToLoginIfUnauthenticatedMiddleware.
+"""
+from rest_framework.permissions import BasePermission, IsAuthenticated
+
+
+class LoginRedirectIfUnauthenticated(IsAuthenticated):
+    """
+    A DRF permission class that will login redirect unauthorized users.
+
+    It can be used to convert a plain Django view that was using @login_required
+    into a DRF APIView, which is useful to enable our DRF JwtAuthentication class.
+
+    Requires JwtRedirectToLoginIfUnauthenticatedMiddleware to work.
+
+    """
+    pass

--- a/edx_rest_framework_extensions/utils.py
+++ b/edx_rest_framework_extensions/utils.py
@@ -3,3 +3,12 @@
 # for compatibility with rest_framework_jwt
 # pylint: disable=unused-import
 from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler
+
+
+def get_username_param(request):
+    user_parameter_name = 'username'
+    url_username = (
+        getattr(request, 'parser_context', {}).get('kwargs', {}).get(user_parameter_name, '') or
+        request.GET.get(user_parameter_name, '')
+    )
+    return url_username.lower()


### PR DESCRIPTION
This PR reorganizes the Permission classes so the purpose of each set of Permissions is more clear. In particular, Permissions related to enforcing OAuth Scopes and Restricted Applications were intermixed with other Basic permissions, which added confusion on what needed to be used.