### PR TITLE
WIP: return None on NotAuthenticated

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,16 @@ Unreleased
 
 *
 
+[6.1.1] - 2020-07-19
+--------------------
+
+Fixed
+~~~~~~~
+
+* Latest `drf-jwt` is throwing error in case of any other Authorization Header. Fixing that issue in `JwtAuthentication` class.
+
+
+
 [6.1.0] - 2020-06-26
 --------------------
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '6.1.0'  # pragma: no cover
+__version__ = '6.1.1'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -59,6 +59,12 @@ class JwtAuthentication(JSONWebTokenAuthentication):
         return get_setting('JWT_PAYLOAD_MERGEABLE_USER_ATTRIBUTES')
 
     def authenticate(self, request):
+        # latest drf-jwt version throws error for any other value other than jwt. So returns None and pass it to other
+        # Authentication class
+        auth_header_value = request.environ.get('HTTP_AUTHORIZATION')
+        if auth_header_value and not auth_header_value.lower().startswith('jwt'):
+            return None
+
         try:
             user_and_auth = super(JwtAuthentication, self).authenticate(request)
 

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
@@ -205,3 +205,16 @@ class JwtAuthenticationTests(TestCase):
 
         decoded_jwt = authentication.get_decoded_jwt_from_auth(mock_request_with_cookie)
         self.assertEqual(expected_decoded_jwt, decoded_jwt)
+
+    def test_with_explicitly_jwt_authorization(self):
+        """ With JWT header it continues and validates the credentials and throws error. """
+        auth_header = '{token_name} {token}'.format(token_name='JWT', token='wrongvalue')
+        request = RequestFactory().get('/', HTTP_AUTHORIZATION=auth_header)
+        with self.assertRaises(AuthenticationFailed):
+            JwtAuthentication().authenticate(request)
+
+    def test_jwt_returns_none_for_bearer_header(self):
+        """ Returns a None for bearer header request. """
+        auth_header = '{token_name} {token}'.format(token_name='Bearer', token='abc123')
+        request = RequestFactory().get('/', HTTP_AUTHORIZATION=auth_header)
+        self.assertIsNone(JwtAuthentication().authenticate(request))


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-1845

https://github.com/Styria-Digital/django-rest-framework-jwt/pull/27/files#diff-bc0105dbb10d8b2bcacf8d191d5d0195R105
This change is causing issue. Previously it returns None but now it throws exception.


@awais786  have created a PR there https://github.com/Styria-Digital/django-rest-framework-jwt/pull/65 