### PR TITLE
Add default parsers to JWT middleware

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,6 @@ Describe in a couple of sentences what this PR adds
 * **Author concerns:** List any concerns about this PR
 
 **Reviewers:**
-- [ ] @edx/arch-review
 - [ ] tag reviewer
 
 **Merge checklist:**
@@ -27,6 +26,6 @@ Describe in a couple of sentences what this PR adds
 
 **Post merge:**
 - [ ] Create a tag
-- [ ] Check new version is pushed to PyPi after tag-triggered build is 
+- [ ] Check new version is pushed to PyPi after tag-triggered build is
       finished.
 - [ ] Delete working branch (if not needed anymore)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,16 @@ Change Log
 Unreleased
 ----------
 
-*
+
+[6.1.2] - 2020-07-19
+--------------------
+
+Fixed
+~~~~~~~
+
+* `_get_user_from_jwt` no longer throws an `UnsupportedMediaType` error for failing to parse "new user" requests.
+
+
 
 [6.1.1] - 2020-07-19
 --------------------

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '6.1.1'  # pragma: no cover
+__version__ = '6.1.2'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/middleware.py
+++ b/edx_rest_framework_extensions/auth/jwt/middleware.py
@@ -10,6 +10,7 @@ from django.utils.functional import SimpleLazyObject
 from edx_django_utils import monitoring
 from edx_django_utils.cache import RequestCache
 from rest_framework.request import Request
+from rest_framework.settings import api_settings
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
 from edx_rest_framework_extensions.auth.jwt.constants import (
@@ -254,7 +255,10 @@ def _get_user_from_jwt(request, view_func):
     try:
         jwt_authentication_class = _get_jwt_authentication_class(view_func)
         if jwt_authentication_class:
-            user_jwt = jwt_authentication_class().authenticate(Request(request))
+            user_jwt = jwt_authentication_class().authenticate(Request(
+                request,
+                parsers=api_settings.DEFAULT_PARSER_CLASSES
+            ))
             if user_jwt is not None:
                 return user_jwt[0]
             else:


### PR DESCRIPTION
**Description:**
Adds the applications default parsers to the JWT middleware.

When a user was authenticating with a service for the first time, the
middleware was throwing an execption because it couldn't parse the
request. This was because the Request was not given any default parsers
which caused the request to fail on any/all "Content-Type"s.

Example stack trace from before this PR:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/edx_rest_framework_extensions/auth/jwt/middleware.py", line 257, in _get_user_from_jwt
    if jwt_authentication_class:
  File "/usr/local/lib/python3.6/dist-packages/edx_rest_framework_extensions/auth/jwt/authentication.py", line 80, in authenticate
    self.enforce_csrf(request)
  File "/usr/local/lib/python3.6/dist-packages/edx_rest_framework_extensions/auth/jwt/authentication.py", line 167, in enforce_csrf
    reason = check.process_view(request, None, (), {})
  File "/usr/local/lib/python3.6/dist-packages/django/middleware/csrf.py", line 295, in process_view
    request_csrf_token = request.POST.get('csrfmiddlewaretoken', '')
  File "/usr/local/lib/python3.6/dist-packages/rest_framework/request.py", line 424, in POST
    self._load_data_and_files()
  File "/usr/local/lib/python3.6/dist-packages/rest_framework/request.py", line 272, in _load_data_and_files
    self._data, self._files = self._parse()
  File "/usr/local/lib/python3.6/dist-packages/rest_framework/request.py", line 344, in _parse
    raise exceptions.UnsupportedMediaType(media_type)
rest_framework.exceptions.UnsupportedMediaType: Unsupported media type "application/json" in request.
```

**JIRA:**

[MICROBA-498](https://openedx.atlassian.net/browse/MICROBA-498)

**Additional Details**

* **Dependencies:**: N/A
* **Merge deadline:** N/A
* **Testing instructions:** 
1. Create a new account in LMS
2. Make a request to a service that has `ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE` set to `True` (currently ecommerce or demographics). 
3. See an `UnsupportedMediaType` in the logs because there are no matching parsers for the Content-Type passed in (often `"application/json"`)
4. Create another new account in LMS
5. Upgrade the other service to use this branch
6. Again make a request to the service and notice the exception is gone.
* **Author concerns:** N/A

**Reviewers:**
- [x] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Version bump if needed
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
