### PR TITLE
Updated the travis badge to point to travis-ci.com

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,14 @@ Change Log
 Unreleased
 ----------
 
+[6.2.1] - 2020-11-20
+--------------------
+
+Updated
+~~~~~~~
+
+* Updated the travis badge in README.rst to point to travis-ci.com
+
 [6.2.0] - 2020-08-24
 --------------------
 

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ __ https://code.edx.org/
 
 edX Django REST Framework Extensions  |Travis|_ |Codecov|_
 ==========================================================
-.. |Travis| image:: https://travis-ci.org/edx/edx-drf-extensions.svg?branch=master
-.. _Travis: https://travis-ci.org/edx/edx-drf-extensions?branch=master
+.. |Travis| image:: https://travis-ci.com/edx/edx-drf-extensions.svg?branch=master
+.. _Travis: https://travis-ci.com/edx/edx-drf-extensions?branch=master
 
 .. |Codecov| image:: https://codecov.io/github/edx/edx-drf-extensions/coverage.svg?branch=master
 .. _Codecov: https://codecov.io/github/edx/edx-drf-extensions?branch=master

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '6.2.0'  # pragma: no cover
+__version__ = '6.2.1'  # pragma: no cover


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089