### PR TITLE
ARCHBOM-1218: jwt auth monitoring

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,13 +12,30 @@ Change Log
 Unreleased
 ----------
 
+[6.5.0] - 2021-02-12
+--------------------
+
+Added
+~~~~~
+
+* Added a new custom attribute `jwt_auth_failed` to both monitor failures, and to help prepare for future refactors.
+
+
 [6.4.0] - 2021-01-19
 --------------------
 
-Updated
-~~~~~~~
+Added
+~~~~~
 
 * Added a new custom attribute `request_is_staff_or_superuser`
+
+[6.3.0] - 2021-01-12
+--------------------
+
+Removed
+~~~~~~~~
+
+* Drop support for Python 3.5
 
 [6.2.0] - 2020-08-24
 --------------------

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '6.4.0'  # pragma: no cover
+__version__ = '6.5.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -59,12 +59,6 @@ class JwtAuthentication(JSONWebTokenAuthentication):
         return get_setting('JWT_PAYLOAD_MERGEABLE_USER_ATTRIBUTES')
 
     def authenticate(self, request):
-        # latest drf-jwt version throws error for any other value other than jwt. So returns None and pass it to other
-        # Authentication class
-        auth_header_value = request.environ.get('HTTP_AUTHORIZATION')
-        if auth_header_value and not auth_header_value.lower().startswith('jwt'):
-            return None
-
         try:
             user_and_auth = super().authenticate(request)
 

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -5,6 +5,7 @@ import logging
 import jwt
 from django.contrib.auth import get_user_model
 from django.middleware.csrf import CsrfViewMiddleware
+from edx_django_utils.monitoring import set_custom_attribute
 from rest_framework import exceptions
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
@@ -77,11 +78,16 @@ class JwtAuthentication(JSONWebTokenAuthentication):
             return user_and_auth
 
         except jwt.InvalidTokenError as token_error:
+            # Note: I think this case is not used, but will monitor the custom attribute to verify.
+            set_custom_attribute('jwt_auth_failed', 'InvalidTokenError:{}'.format(repr(token_error)))
             raise exceptions.AuthenticationFailed() from token_error
-        except Exception as ex:
+        except Exception as exception:
             # Errors in production do not need to be logged (as they may be noisy),
             # but debug logging can help quickly resolve issues during development.
-            logger.debug(ex)
+            logger.debug('Failed JWT Authentication,', exc_info=exception)
+            # Note: I think this case should only include AuthenticationFailed and PermissionDenied,
+            #   but will monitor the custom attribute to verify.
+            set_custom_attribute('jwt_auth_failed', 'Exception:{}'.format(repr(exception)))
             raise
 
     def authenticate_credentials(self, payload):

--- a/edx_rest_framework_extensions/config.py
+++ b/edx_rest_framework_extensions/config.py
@@ -6,11 +6,9 @@ Application configuration constants and code.
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False
 # .. toggle_description: Toggle for setting request.user with jwt cookie authentication
-# .. toggle_category: micro-frontend
-# .. toggle_use_cases: incremental_release  # pylint: disable=annotation-invalid-choice
+# .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2019-10-15
-# .. toggle_expiration_date: 2019-12-31
+# .. toggle_target_removal_date: 2019-12-31
 # .. toggle_warnings: This feature fixed ecommerce, but broke edx-platform. The toggle enables us to fix over time.
 # .. toggle_tickets: ARCH-1210, ARCH-1199, ARCH-1197
-# .. toggle_status: supported
 ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE = 'ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE'


### PR DESCRIPTION
**Description:**

While working on ARCHBOM-1218 in https://github.com/edx/edx-drf-extensions/pull/129, I realized that some cleanup and monitoring could be moved into a separate PR (a.k.a. this PR) to make the future changes more clear and less risky.

 * feat: add jwt_auth_failed custom attribute

    Adds a jwt_auth_failed custom attribute that can be used for debugging,
    but also will help with some planned cleanup and refactoring in
    ARCHBOM-1218.

* fix: update toggle annotations 

* refactor: remove check for non-jwt tokens
    
    At one point, drf-jwt had an issue introduced where it was raising an
    error instead of returning None for non-jwt tokens, for example, bearer
    tokens. A check was temporarily added to JwtAuthentication to ensure
    that we continued to return None.
    
    Since then, our team got a more permanent fix merged upstream in:
    https://github.com/edx/edx-drf-extensions/pull/136
    
    We will keep the unit test added with the original fix to ensure that
    this continues to work.


**JIRA:**

[ARCHBOM-1218](https://openedx.atlassian.net/browse/ARCHBOM-1218)

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [X] Version bump if needed
- [X] Changelog record added
- [ ] ~~Documentation updated (not only docstrings)~~
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
