### PR TITLE
feat: Latest pyjwt version has breaking changes and was causing tests failures. 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,15 @@ Change Log
 Unreleased
 ----------
 
+[7.0.0] - 2021-08-03
+--------------------
+
+Changed
+~~~~~~~
+
+* **BREAKING CHANGE:** ``generate_jwt_token``: Now returns string (instead of bytes), and no longer requires decoding. This was to keep consistent with change to ``jwt.encode`` in `pyjwt` upgrade (see below).
+* **BREAKING CHANGE:** Upgraded dependency ``pyjwt[crypto]`` to 2.1.0, which introduces its own breaking changes that may affect consumers of this library. Pay careful attention to the 2.0.0 breaking changes documented in https://pyjwt.readthedocs.io/en/stable/changelog.html#v2-0-0.
+
 [6.6.0] - 2021-07-13
 --------------------
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '6.6.0'  # pragma: no cover
+__version__ = '7.0.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/decoder.py
+++ b/edx_rest_framework_extensions/auth/jwt/decoder.py
@@ -174,7 +174,6 @@ def _decode_and_verify_token(token, jwt_issuer):
     decoded_token = jwt.decode(
         token,
         jwt_issuer['SECRET_KEY'],
-        api_settings.JWT_VERIFY,
         options=options,
         leeway=api_settings.JWT_LEEWAY,
         audience=jwt_issuer['AUDIENCE'],

--- a/edx_rest_framework_extensions/auth/jwt/tests/utils.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/utils.py
@@ -23,7 +23,7 @@ def generate_jwt_token(payload, signing_key=None):
     Generate a valid JWT token for authenticated requests.
     """
     signing_key = signing_key or settings.JWT_AUTH['JWT_ISSUERS'][0]['SECRET_KEY']
-    return jwt.encode(payload, signing_key).decode('utf-8')
+    return jwt.encode(payload, signing_key)
 
 
 def generate_latest_version_payload(user, scopes=None, filters=None, version=None,

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,6 +7,7 @@ django-waffle
 edx-django-utils>=3.8.0      # using new set_custom_attribute method
 edx-opaque-keys
 pyjwkest
+pyjwt[crypto]>=2.1.0      # depends on newer jwt.decode and jwt.encode
 python-dateutil>=2.0
 requests>=2.7.0
 rest-condition>=1.0.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -56,9 +56,9 @@ pycryptodomex==3.10.1
     # via pyjwkest
 pyjwkest==1.4.2
     # via -r requirements/base.in
-pyjwt[crypto]==1.7.1
+pyjwt[crypto]==2.1.0
     # via
-    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
     #   drf-jwt
 pymongo==3.12.0
     # via edx-opaque-keys

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -23,3 +23,6 @@ drf-jwt<1.19.1
 
 # latest version requires PyJWT>=2.0.0 but drf-jwt requires PyJWT[crypto]<2.0.0,>=1.5.2
 social-auth-core<4.0.3
+
+# 5.0.0+ of social-auth-app-django requires social-auth-core>=4.1.0
+social-auth-app-django<5.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,6 +10,3 @@
 
 # This file contains all common constraints for edx-repos
 -c common_constraints.txt
-
-# greater versions causing tests failures.
-pyjwt[crypto]==1.7.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -229,9 +229,8 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
-pyjwt[crypto]==1.7.1
+pyjwt[crypto]==2.1.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   drf-jwt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -146,9 +146,8 @@ pycryptodomex==3.10.1
     #   pyjwkest
 pyjwkest==1.4.2
     # via -r requirements/base.txt
-pyjwt[crypto]==1.7.1
+pyjwt[crypto]==2.1.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   drf-jwt
 pylint==2.9.6


### PR DESCRIPTION
This PR constains major changes.
---------------------------
* **BREAKING CHANGE:** ``generate_jwt_token``: Now returns string (instead of bytes), and no longer requires decoding. This was to keep consistent with change to ``jwt.encode`` in `pyjwt` upgrade (see below).
* **BREAKING CHANGE:** Upgraded dependency ``pyjwt[crypto]`` to 2.1.0, which introduces its own breaking changes that may affect consumers of this library. Pay careful attention to the 2.0.0 breaking changes documented in https://pyjwt.readthedocs.io/en/stable/changelog.html#v2-0-0.
---------------------------

https://openedx.atlassian.net/browse/BOM-2470
https://pyjwt.readthedocs.io/en/stable/changelog.html#v2-0-0

This PR is fixing two issues.

Issue 1.  decode method was throwing following error.
```
decoded_token = jwt.decode(
            token,
            jwt_issuer['SECRET_KEY'],
            api_settings.JWT_VERIFY,
            options=options,
            leeway=api_settings.JWT_LEEWAY,
            audience=jwt_issuer['AUDIENCE'],
            issuer=jwt_issuer['ISSUER'],
            algorithms=[api_settings.JWT_ALGORITHM],
        )
E       TypeError: decode() got multiple values for argument 'algorithms'
edx_rest_framework_extensions/auth/jwt/decoder.py:174: TypeError
```
Root Cause. Latest version does not have the `verify` variable. 
They moved that into options dict in following prs.

https://github.com/jpadilla/pyjwt/pull/515/files
https://github.com/jpadilla/pyjwt/pull/271/files

---------------------------------------------------------------------------------------------------------------------
Issue 2.
Few tests were failing due to the following error

```
    def generate_jwt_token(payload, signing_key=None):
        """
        Generate a valid JWT token for authenticated requests.
        """
        signing_key = signing_key or settings.JWT_AUTH['JWT_ISSUERS'][0]['SECRET_KEY']
        import pdb;
        pdb.set_trace()
>       return jwt.encode(payload, signing_key).decode('utf-8')
E       AttributeError: 'str' object has no attribute 'decode'

```
It was changed in this [PR](https://github.com/jpadilla/pyjwt/pull/513)
