### PR TITLE
build: Implemented common-constraint local sync.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ $(COMMON_CONSTRAINTS_TXT):
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: $(COMMON_CONSTRAINTS_TXT)
 upgrade: upgrade-piptools piptools ## upgrade requirement pins.
+	sed 's/pyjwt\[crypto\]==1.7.1//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	mv requirements/common_constraints.tmp requirements/common_constraints.txt
 	pip-compile --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile requirements/base.in --upgrade -o requirements/base.txt
 	pip-compile requirements/test.in --upgrade -o requirements/test.txt

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,13 @@ piptools: ## install pip-compile and pip-sync.
 upgrade-piptools: piptools # upgrade pip-tools using pip-tools.
 	pip-compile requirements/pip-tools.in --rebuild --upgrade -o requirements/pip-tools.txt
 
+COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
+.PHONY: $(COMMON_CONSTRAINTS_TXT)
+$(COMMON_CONSTRAINTS_TXT):
+	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
+
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
+upgrade: $(COMMON_CONSTRAINTS_TXT)
 upgrade: upgrade-piptools piptools ## upgrade requirement pins.
 	pip-compile --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile requirements/base.in --upgrade -o requirements/base.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ cryptography==3.4.7
     # via pyjwt
 django==2.2.24
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
     #   django-crum
     #   djangorestframework
@@ -34,7 +34,7 @@ djangorestframework==3.12.4
     #   rest-condition
 drf-jwt==1.19.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
 edx-django-utils==4.2.0
     # via -r requirements/base.in
@@ -58,7 +58,6 @@ pyjwkest==1.4.2
     # via -r requirements/base.in
 pyjwt[crypto]==1.7.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   drf-jwt
 pymongo==3.12.0

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,0 +1,22 @@
+# A central location for most common version constraints
+# (across edx repos) for pip-installation.
+#
+# Similar to other constraint files this file doesn't install any packages.
+# It specifies version constraints that will be applied if a package is needed.
+# When pinning something here, please provide an explanation of why it is a good
+# idea to pin this package across all edx repos, Ideally, link to other information
+# that will help people in the future to remove the pin when possible.
+# Writing an issue against the offending project and linking to it here is good.
+#
+# Note: Changes to this file will automatically be used by other repos, referencing
+#  this file from Github directly. It does not require packaging in edx-lint.
+
+
+# using LTS django version
+Django<2.3
+
+# latest version is causing e2e failures in edx-platform.
+drf-jwt<1.19.1
+
+# Newer versions causing tests failures in multiple repos.
+pyjwt[crypto]==1.7.1

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -19,4 +19,4 @@ Django<2.3
 drf-jwt<1.19.1
 
 # Newer versions causing tests failures in multiple repos.
-pyjwt[crypto]==1.7.1
+

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -9,7 +9,4 @@
 # linking to it here is good.
 
 # This file contains all common constraints for edx-repos
--c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-
-# greater versions causing tests failures.
-pyjwt[crypto]==1.7.1
+-c common_constraints.txt

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,3 +10,6 @@
 
 # This file contains all common constraints for edx-repos
 -c common_constraints.txt
+
+# greater versions causing tests failures.
+pyjwt[crypto]==1.7.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -73,7 +73,7 @@ distlib==0.3.2
     #   virtualenv
 django==2.2.24
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   django-crum
@@ -105,7 +105,7 @@ docutils==0.16
     #   sphinx-rtd-theme
 drf-jwt==1.19.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/test.txt
 edx-django-utils==4.2.0
@@ -231,7 +231,6 @@ pyjwkest==1.4.2
     #   -r requirements/test.txt
 pyjwt[crypto]==1.7.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/test.txt

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,7 +10,7 @@ pep517==0.11.0
     # via pip-tools
 pip-tools==6.2.0
     # via -r requirements/pip-tools.in
-tomli==1.1.0
+tomli==1.2.0
     # via pep517
 wheel==0.36.2
     # via pip-tools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -46,7 +46,7 @@ ddt==1.4.2
 distlib==0.3.2
     # via virtualenv
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
     #   django-crum
     #   djangorestframework
@@ -68,7 +68,7 @@ django-waffle==2.2.1
     #   rest-condition
 drf-jwt==1.19.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
 edx-django-utils==4.2.0
     # via -r requirements/base.txt
@@ -148,7 +148,6 @@ pyjwkest==1.4.2
     # via -r requirements/base.txt
 pyjwt[crypto]==1.7.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   drf-jwt


### PR DESCRIPTION
Implemented common-constraint local sync. It gives us more control in case of different version implementation.

pip-tools gives error if two different versions of same package appears in make upgrade job. To fix this problem, added common constraint locally. It will always sync with web-url. With this approach this issue can be resolve.
