### PR TITLE
fix: replace dropped require_exp and require_iat with require option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,16 @@ Change Log
 Unreleased
 ----------
 
+[7.0.1] - 2021-08-10
+--------------------
+
+Fixed
+~~~~~
+
+* Removed dropped ``require_exp`` and ``require_iat`` options from jwt.decode and instead used ``require`` option with both ``exp`` and ``iat``. For more info visit this: https://pyjwt.readthedocs.io/en/stable/changelog.html#dropped-deprecated-require-options-in-jwt-decode
+* This fixes an error in previous release which had a multiple breaking changes
+
+
 [7.0.0] - 2021-08-03
 --------------------
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '7.0.0'  # pragma: no cover
+__version__ = '7.0.1'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/decoder.py
+++ b/edx_rest_framework_extensions/auth/jwt/decoder.py
@@ -162,8 +162,7 @@ def _verify_jwt_signature(token, jwt_issuer):
 
 def _decode_and_verify_token(token, jwt_issuer):
     options = {
-        'require_exp': True,
-        'require_iat': True,
+        'require': ["exp", "iat"],
 
         'verify_exp': api_settings.JWT_VERIFY_EXPIRATION,
         'verify_aud': settings.JWT_AUTH.get('JWT_VERIFY_AUDIENCE', True),

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_decoder.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_decoder.py
@@ -165,6 +165,18 @@ class JWTDecodeHandlerTests(TestCase):
 
             patched_log.exception.assert_any_call("Token verification failed.")
 
+    @ddt.data("exp", "iat")
+    def test_required_claims(self, claim):
+        """
+        Verify that tokens that do not carry 'exp' or 'iat' claims are rejected
+        """
+        # Deletes required claim from payload
+        del self.payload[claim]
+        token = generate_jwt_token(self.payload)
+        with self.assertRaises(jwt.MissingRequiredClaimError):
+            # Decode to see if MissingRequiredClaimError exception is raised or not
+            jwt_decode_handler(token)
+
 
 def _jwt_decode_handler_with_defaults(token):  # pylint: disable=unused-argument
     """


### PR DESCRIPTION
**Description:**

Removed dropped ``require_exp`` and ``require_iat`` options from jwt.decode and instead used ``require`` option with both ``exp`` and ``iat``. For more info visit this: https://pyjwt.readthedocs.io/en/stable/changelog.html#dropped-deprecated-require-options-in-jwt-decode

**JIRA:**

[BOM-2470](https://openedx.atlassian.net/browse/BOM-2470)

**Reviewers:**
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bump if needed
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
