### PR TITLE
feat!: Add support for permissions composed using DRF

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,15 @@ Change Log
 Unreleased
 ----------
 
+[8.0.0] - 2021-09-30
+--------------------
+
+Changed
+~~~~~~~
+
+* **BREAKING CHANGE:** Updated ``EnsureJWTAuthSettingsMiddleware`` to understand and work with permissions combined using DRF's in-built support. This allows switching away from ``rest_condition``. Any view that still uses ``rest_condition`` will cause the middleware to throw an error. 
+
+
 [7.0.1] - 2021-08-10
 --------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,9 +9,9 @@ for developing on the edX platform.
 Requirements
 ------------
 
-* Python (2.7, 3.5, 3.6)
-* Django (1.8, 1.9, 1.10, 1.11)
-* Django REST Framework (3.2+)
+* Python (3.8+)
+* Django (2.2, 3.2)
+* Django REST Framework (3.9+)
 
 Installation
 ------------

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '7.0.1'  # pragma: no cover
+__version__ = '8.0.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/permissions.py
+++ b/edx_rest_framework_extensions/permissions.py
@@ -2,7 +2,6 @@
 import logging
 
 from opaque_keys.edx.keys import CourseKey
-from rest_condition import C
 from rest_framework.permissions import BasePermission, IsAuthenticated
 
 from edx_rest_framework_extensions.auth.jwt.authentication import is_jwt_authenticated
@@ -161,15 +160,15 @@ class LoginRedirectIfUnauthenticated(IsAuthenticated):
     """
 
 
-_NOT_JWT_RESTRICTED_PERMISSIONS = C(NotJwtRestrictedApplication) & (C(IsStaff) | IsUserInUrl)
+_NOT_JWT_RESTRICTED_PERMISSIONS = NotJwtRestrictedApplication & (IsStaff | IsUserInUrl)
 _JWT_RESTRICTED_PERMISSIONS = (
-    C(JwtRestrictedApplication) &
+    JwtRestrictedApplication &
     JwtHasScope &
     JwtHasContentOrgFilterForRequestedCourse &
     JwtHasUserFilterForRequestedUser
 )
 JWT_RESTRICTED_APPLICATION_OR_USER_ACCESS = (
-    C(IsAuthenticated) &
+    IsAuthenticated &
     (_NOT_JWT_RESTRICTED_PERMISSIONS | _JWT_RESTRICTED_PERMISSIONS)
 )
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,7 +1,7 @@
 -c constraints.txt
 
 Django>=2.2
-djangorestframework>=3.2.0
+djangorestframework>=3.9.0
 drf-jwt
 django-waffle
 edx-django-utils>=3.8.0      # using new set_custom_attribute method
@@ -10,6 +10,5 @@ pyjwkest
 pyjwt[crypto]>=2.1.0      # depends on newer jwt.decode and jwt.encode
 python-dateutil>=2.0
 requests>=2.7.0
-rest-condition>=1.0.3
 semantic_version
 six

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,6 @@ django==2.2.24
     #   djangorestframework
     #   drf-jwt
     #   edx-django-utils
-    #   rest-condition
 django-crum==0.7.9
     # via edx-django-utils
 django-waffle==2.2.1
@@ -31,7 +30,6 @@ djangorestframework==3.12.4
     # via
     #   -r requirements/base.in
     #   drf-jwt
-    #   rest-condition
 drf-jwt==1.19.0
     # via
     #   -c requirements/common_constraints.txt
@@ -70,8 +68,6 @@ requests==2.26.0
     # via
     #   -r requirements/base.in
     #   pyjwkest
-rest-condition==1.0.3
-    # via -r requirements/base.in
 semantic-version==2.8.5
     # via -r requirements/base.in
 six==1.16.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -80,7 +80,6 @@ django==2.2.24
     #   djangorestframework
     #   drf-jwt
     #   edx-django-utils
-    #   rest-condition
 django-crum==0.7.9
     # via
     #   -r requirements/base.txt
@@ -96,7 +95,6 @@ djangorestframework==3.12.4
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   drf-jwt
-    #   rest-condition
 docutils==0.17.1
     # via
     #   -r requirements/docs.txt
@@ -300,10 +298,6 @@ requests==2.26.0
     #   -r requirements/test.txt
     #   pyjwkest
     #   sphinx
-rest-condition==1.0.3
-    # via
-    #   -r requirements/base.txt
-    #   -r requirements/test.txt
 semantic-version==2.8.5
     # via
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -52,7 +52,6 @@ distlib==0.3.3
     #   djangorestframework
     #   drf-jwt
     #   edx-django-utils
-    #   rest-condition
 django-crum==0.7.9
     # via
     #   -r requirements/base.txt
@@ -64,7 +63,6 @@ django-waffle==2.2.1
     # via
     #   -r requirements/base.txt
     #   drf-jwt
-    #   rest-condition
 drf-jwt==1.19.0
     # via
     #   -c requirements/common_constraints.txt
@@ -195,8 +193,6 @@ requests==2.26.0
     # via
     #   -r requirements/base.txt
     #   pyjwkest
-rest-condition==1.0.3
-    # via -r requirements/base.txt
 semantic-version==2.8.5
     # via -r requirements/base.txt
 six==1.16.0


### PR DESCRIPTION
**Description:**
Currently rest_condition is used to compose permission classes, however support
for composition is now part of DRF since v3.9 and rest_condition has not seen
updates in a while.

This change adds support for DRF-style composition to the middleware.

https://github.com/edx/upgrades/issues/2

**Reviewers:**
- [ ] 

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bump if needed
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
